### PR TITLE
full info broadcast in add/move/delete track

### DIFF
--- a/apps/playlists/urls.py
+++ b/apps/playlists/urls.py
@@ -5,7 +5,7 @@ urlpatterns = [
     path('playlists', views.create_new_playlist, name='playlists'),
     path('playlists/<int:playlist_id>', views.get_playlist_info, name='get_playlist'), 
     path('playlists/<int:playlist_id>/tracks', views.add_items_to_playlist, name='add_items'),
-    path('playlists/<int:playlist_id>/remove_tracks', views.remove_playlist_items, name='remove_items'),
+    path('playlists/<int:playlist_id>/remove_tracks', views.delete_track_from_playlist, name='remove_items'),
     # do not need ?
     #path('save_playlist/', views.save_shared_playlist, name='save_playlist'),
     path('saved_playlists/', views.get_user_saved_playlists, name='saved_playlists'),


### PR DESCRIPTION
Please take a look. I changed API for single tracks only to be **added** and **deleted** as its less complicate to maintain positions in a list but keep the old path (can change later):

path('playlists/<int:playlist_id>/remove_tracks', views.delete_track_from_playlist, name='remove_items'), **DELETE**
path('<int:playlist_id>/add/', views.add_track), **ADD**

