### PR TITLE
Add profile public/private/friend/music info #65

### DIFF
--- a/apps/profile/admin.py
+++ b/apps/profile/admin.py
@@ -1,0 +1,13 @@
+# Register your models here.
+
+from django.contrib import admin
+
+from .models import ProfilePublic
+from .models import ProfilePrivate
+from .models import ProfileFriend
+from .models import ProfileMusic
+
+admin.site.register(ProfilePublic)
+admin.site.register(ProfilePrivate)
+admin.site.register(ProfileFriend)
+admin.site.register(ProfileMusic)

--- a/apps/profile/apps.py
+++ b/apps/profile/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AuthConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'apps.profile'

--- a/apps/profile/models.py
+++ b/apps/profile/models.py
@@ -1,0 +1,163 @@
+from django.db import models
+from django.contrib.auth.models import User
+from django.contrib.postgres.fields import ArrayField
+
+
+class ProfilePublic(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile_public')
+
+    gender = models.CharField(
+        max_length=6,
+        choices=[('female', 'female'), ('male', 'male')],
+        null=True,
+        blank=True
+        )
+    
+    avatar = models.CharField(
+        max_length=100,
+        null=True,
+        blank=True,
+        default=''
+        )
+    
+    location = models.CharField(
+        max_length=50,
+        null=True,
+        blank=True,
+        default=''
+        )
+    
+    bio = models.CharField(
+        max_length=500,
+        null=True,
+        blank=True,
+        default=''
+        )
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "User Public Info"
+        verbose_name_plural = "User Public Infos"
+        
+    def __str__(self):
+        return (
+            f"user id: {self.user.id}, gender: {self.gender}, avatar: {self.avatar},"
+            f"location: {self.location}, bio: {self.bio}"
+            )
+
+
+class ProfilePrivate(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile_private')
+
+    first_name = models.CharField(
+        max_length=50,
+        null=True,
+        blank=True,
+        default=''
+        )
+    
+    last_name = models.CharField(
+        max_length=50,
+        null=True,
+        blank=True,
+        default=''
+        )
+
+    phone = models.CharField(
+        max_length=10,
+        null=True,
+        blank=True,
+        default=''
+        )
+    
+    street = models.CharField(
+        max_length=100,
+        null=True,
+        blank=True,
+        default=''
+        )
+    
+    country = models.CharField(
+        max_length=50,
+        null=True,
+        blank=True,
+        default=''
+        )
+    
+    postal_code = models.CharField(
+        max_length=10,
+        null=True,
+        blank=True,
+        default=''
+        )
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "User Private Info"
+        verbose_name_plural = "User Private Infos"
+        
+    def __str__(self):
+        return (
+            f"user id: {self.user.id}, first_name: {self.first_name}, last_name: {self.last_name},"
+            f"phone: {self.phone}, street: {self.street}, country: {self.country}, postal_code: {self.postal_code}"
+            )
+
+
+class ProfileFriend(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile_friend')
+
+    dob = models.DateField(
+        null=True, 
+        blank=True
+    )
+    
+    hobbies = ArrayField(
+        models.CharField(max_length=50),
+        blank=True,
+        default=list
+    )
+
+    friend_info = models.CharField(
+        max_length=500,
+        null=True,
+        blank=True,
+        default=''
+    )
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "User Friend Info"
+        verbose_name_plural = "User Friend Infos"
+        
+    def __str__(self):
+        return (
+            f"user id: {self.user.id}, dob: {self.dob}, hobbies: {self.hobbies}, friend_info: {self.friend_info}"
+        )
+
+
+class ProfileMusic(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile_music')
+    
+    music_preferences = ArrayField(
+        models.CharField(max_length=50),
+        blank=True,
+        default=list
+    )
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "User Music Preference"
+        verbose_name_plural = "User Music Preferences"
+        
+    def __str__(self):
+        return (
+            f"user id: {self.user.id}, music_preferences: {self.music_preferences}"
+        )

--- a/apps/profile/urls.py
+++ b/apps/profile/urls.py
@@ -1,0 +1,15 @@
+from django.urls import path
+from . import views
+from django.conf import settings
+
+urlpatterns = [
+    path('public/', views.public_info, name='public_info'),
+    path('friend/', views.friend_info, name='friend_info'),
+    path('private/', views.private_info, name='private_info'),
+    path('music/', views.music_preferences, name='music_preferences'),
+    path('public/update/', views.update_public_info, name='update_public_info'),
+    path('friend/update/', views.update_friend_info, name='update_friend_info'),
+    path('private/update/', views.update_private_info, name='update_private_info'),
+    path('music/update/', views.update_music_preferences, name='update_music_pref'),
+
+]

--- a/apps/profile/views.py
+++ b/apps/profile/views.py
@@ -1,0 +1,278 @@
+import os
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from django.http import JsonResponse
+from rest_framework import status
+from django.contrib.auth import get_user_model
+import requests
+from rest_framework.response import Response
+from rest_framework.authtoken.models import Token
+from .models import ProfilePublic
+from .models import ProfilePrivate
+from .models import ProfileFriend
+from .models import ProfileMusic
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
+from django.conf import settings
+import base64
+import uuid
+from urllib.parse import urljoin
+
+
+User = get_user_model()
+
+
+@api_view(['POST'])
+@authentication_classes([TokenAuthentication])
+@permission_classes([IsAuthenticated])
+def update_public_info(request):
+    user = request.user
+    avatar_base64 = request.data.get('avatarBase64')
+    mime_type = request.data.get('mimeType')
+    gender = request.data.get('gender')
+    location = request.data.get('location')
+    bio = request.data.get('bio')
+    
+    try:
+        profile_public = ProfilePublic.objects.filter(user=user).first()
+        if not profile_public:
+            profile_public = ProfilePublic.objects.create(
+                user = user,
+            )
+        if mime_type and avatar_base64:
+            ext = '.' + mime_type.split('/')[1]
+            filename = uuid.uuid4().hex + ext
+            file_data = base64.b64decode(avatar_base64)
+            save_dir = os.path.join(settings.MEDIA_ROOT)
+            file_path = os.path.join(save_dir, filename)
+            with open(file_path, 'wb') as f:
+                f.write(file_data)
+            media_url = urljoin(settings.MEDIA_URL, filename)
+            if file_path:
+                profile_public.avatar = media_url
+
+        if gender:
+            profile_public.gender = gender
+        
+        if location:
+            profile_public.location = location
+        
+        if bio:
+            profile_public.bio = bio
+        
+        profile_public.save()
+
+        data = {
+            'avatar': profile_public.avatar,
+            'gender': profile_public.gender,
+            'location': profile_public.location,
+            'bio': profile_public.bio,
+        }
+        return JsonResponse(data, status=status.HTTP_200_OK)
+        
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['GET'])
+@authentication_classes([TokenAuthentication])
+@permission_classes([IsAuthenticated])
+def public_info(request):
+    user = request.user
+    try:
+        profile_public = ProfilePublic.objects.filter(user=user).first()
+        if not profile_public:
+            profile_public = ProfilePublic.objects.create(
+                user = user,
+            )
+        data = {
+            'avatar': profile_public.avatar,
+            'gender': profile_public.gender,
+            'location': profile_public.location,
+            'bio': profile_public.bio,   
+        }
+        return JsonResponse(data, status=status.HTTP_200_OK)
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['POST'])
+@authentication_classes([TokenAuthentication])
+@permission_classes([IsAuthenticated])
+def update_private_info(request):
+    user = request.user
+    first_name = request.data.get('firstName')
+    last_name = request.data.get('lastName')
+    phone = request.data.get('phone')
+    street = request.data.get('street')
+    country = request.data.get('country')
+    postal_code = request.data.get('postalCode')
+    
+    try:
+        profile_private = ProfilePrivate.objects.filter(user=user).first()
+        if not profile_private:
+            profile_private = ProfilePrivate.objects.create(
+                user = user,
+            )
+    
+        if first_name:
+            profile_private.first_name = first_name
+        
+        if last_name:
+            profile_private.last_name = last_name
+
+        if phone:
+            profile_private.phone = phone
+        
+        if street:
+            profile_private.street = street
+        
+        if country:
+            profile_private.country = country
+        
+        if postal_code:
+            profile_private.postal_code = postal_code
+        
+        profile_private.save()
+
+        data = {
+            'first_name': profile_private.first_name,
+            'last_name': profile_private.last_name,
+            'phone': profile_private.phone,
+            'street': profile_private.street,
+            'country': profile_private.country,
+            'postal_code': profile_private.postal_code
+        }
+        return JsonResponse(data, status=status.HTTP_200_OK)
+        
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['GET'])
+@authentication_classes([TokenAuthentication])
+@permission_classes([IsAuthenticated])
+def private_info(request):
+    user = request.user
+    try:
+        profile_private = ProfilePrivate.objects.filter(user=user).first()
+        if not profile_private:
+            profile_private = ProfilePrivate.objects.create(
+                user = user,
+            )
+        data = {
+            'first_name': profile_private.first_name,
+            'last_name': profile_private.last_name,
+            'phone': profile_private.phone,
+            'street': profile_private.street,
+            'country': profile_private.country,
+            'postal_code': profile_private.postal_code
+        }
+        return JsonResponse(data, status=status.HTTP_200_OK)
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['POST'])
+@authentication_classes([TokenAuthentication])
+@permission_classes([IsAuthenticated])
+def update_friend_info(request):
+    user = request.user
+    dob = request.data.get('dob')
+    hobbies = request.data.get('hobbies', [])
+    friend_info = request.data.get('friendInfo')
+    
+    try:
+        profile_friend = ProfileFriend.objects.filter(user=user).first()
+        if not profile_friend:
+            profile_friend = ProfileFriend.objects.create(
+                user = user,
+            )
+    
+        if dob:
+            profile_friend.dob = dob
+        
+        if hobbies:
+            profile_friend.hobbies = hobbies
+
+        if friend_info:
+            profile_friend.friend_info = friend_info
+        
+        profile_friend.save()
+
+        data = {
+            'dob': profile_friend.dob,
+            'hobbies': profile_friend.hobbies,
+            'friend_info': profile_friend.friend_info
+        }
+        return JsonResponse(data, status=status.HTTP_200_OK)
+        
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['GET'])
+@authentication_classes([TokenAuthentication])
+@permission_classes([IsAuthenticated])
+def friend_info(request):
+    user = request.user
+    try:
+        profile_friend = ProfileFriend.objects.filter(user=user).first()
+        if not profile_friend:
+            profile_friend = ProfileFriend.objects.create(
+                user = user,
+            )
+        data = {
+            'dob': profile_friend.dob,
+            'hobbies': profile_friend.hobbies,
+            'friend_info': profile_friend.friend_info
+        }
+        return JsonResponse(data, status=status.HTTP_200_OK)
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['POST'])
+@authentication_classes([TokenAuthentication])
+@permission_classes([IsAuthenticated])
+def update_music_preferences(request):
+    user = request.user
+    music_preferences = request.data.get('musicPreferences', [])
+    
+    try:
+        profile_music = ProfileMusic.objects.filter(user=user).first()
+        if not profile_music:
+            profile_music = ProfileMusic.objects.create(
+                user = user,
+            )
+        
+        if music_preferences:
+            profile_music.music_preferences = music_preferences
+        
+        profile_music.save()
+
+        data = {
+            'music_preferences': profile_music.music_preferences,
+        }
+        return JsonResponse(data, status=status.HTTP_200_OK)
+        
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['GET'])
+@authentication_classes([TokenAuthentication])
+@permission_classes([IsAuthenticated])
+def music_preferences(request):
+    user = request.user
+    try:
+        profile_music = ProfileMusic.objects.filter(user=user).first()
+        if not profile_music:
+            profile_music = ProfileMusic.objects.create(
+                user = user,
+            )
+        data = {
+            'music_preferences': profile_music.music_preferences,
+        }
+        return JsonResponse(data, status=status.HTTP_200_OK)
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -176,7 +176,7 @@ def forgot_password(request):
         return JsonResponse({'error': 'User passwords cannot be reset.'}, status=status.HTTP_400_BAD_REQUEST)
 
     otp = utils.create_otp_for_user(user)
-    print(f"otp {otp}")
+
     if not otp:
         return JsonResponse({'error': 'OTP creation failed.'}, status=status.HTTP_404_NOT_FOUND)
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'channels',
     'apps.remote_auth',
+    'apps.profile',
 ]
 
 MIDDLEWARE = [
@@ -190,3 +191,7 @@ EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
+
+
+MEDIA_URL = '/apps/avatars/'
+MEDIA_ROOT = BASE_DIR / 'apps/avatars'

--- a/core/urls.py
+++ b/core/urls.py
@@ -16,6 +16,8 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -25,4 +27,7 @@ urlpatterns = [
     path('playlists/', include('apps.playlists.urls')),
     path('devices/', include('apps.devices.urls')),
     path('auth/', include('apps.remote_auth.urls')),
+    path('profile/', include('apps.profile.urls')),
 ]
+
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,6 +16,7 @@ export PYTHONPATH=/app
 
 echo "Applying migrations..."
 python manage.py makemigrations
+python manage.py makemigrations profile
 python manage.py migrate
 echo "Loading data..."
 if [ -f "/app/sample.json" ]; then

--- a/frontend-dart/lib/providers/profile_provider.dart
+++ b/frontend-dart/lib/providers/profile_provider.dart
@@ -1,15 +1,17 @@
 // lib/providers/profile_provider.dart
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
-import 'base_provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
+import '../services/profile_api_service.dart';
 
-class ProfileProvider with ChangeNotifier, BaseProvider {
+
+class ProfileProvider with ChangeNotifier {
   final ApiService _apiService = ApiService();
+  final ProfileApiService _profileApiService = ProfileApiService();
   
   String? _userId;
   String? _username;
@@ -19,7 +21,23 @@ class ProfileProvider with ChangeNotifier, BaseProvider {
   String? _socialType;
   String? _socialId;
   bool _isPasswordUsable = false;
-  GoogleSignIn? googleSignIn;
+  bool _isLoading = false;
+  String? _errorMessage;
+  String? _avatar;
+  String? _gender;
+  String? _location;
+  String? _bio;
+  String? _firstName;
+  String? _lastName;
+  String? _phone;
+  String? _street;
+  String? _country;
+  String? _postalCode;
+  DateTime? _dob;
+  List<String>? _hobbies;
+  String? _friendInfo;
+  List<String>? _musicPreferences;
+  
 
   String? get userId => _userId;
   String? get username => _username;
@@ -28,18 +46,44 @@ class ProfileProvider with ChangeNotifier, BaseProvider {
   String? get socialName => _socialName;
   String? get socialType => _socialType;
   String? get socialId => _socialId;
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+  bool get hasError => _errorMessage != null;
   bool get isPasswordUsable => _isPasswordUsable;
+  String? get avatar => _avatar;
+  String? get gender => _gender;
+  String? get location => _location;
+  String? get bio => _bio;
+  String? get firstName => _firstName;
+  String? get lastName => _lastName;
+  String? get phone => _phone;
+  String? get street => _street;
+  String? get country => _country;
+  String? get postalCode => _postalCode;
+  DateTime? get dob => _dob;
+  List<String>? get hobbies => _hobbies;
+  String? get friendInfo => _friendInfo;
+  List<String>? get musicPreferences => _musicPreferences;
+  
+  GoogleSignIn? googleSignIn;
 
   ProfileProvider() {
+
     if (!kIsWeb) {
       googleSignIn = GoogleSignIn(
-        scopes: ['email', 'profile', 'openid'],
-        clientId: dotenv.env['GOOGLE_CLIENT_ID_APP'],
+      scopes: ['email', 'profile', 'openid'],
+      clientId: dotenv.env['GOOGLE_CLIENT_ID_APP'],
       );
     }
+
   }
 
-  void resetValues() {
+  void clearError() {
+    _errorMessage = null;
+    notifyListeners();
+  }
+
+  void resetValues(){
     _userId = null;
     _username = null;
     _userEmail = null;
@@ -48,11 +92,30 @@ class ProfileProvider with ChangeNotifier, BaseProvider {
     _socialEmail = null;
     _socialName = null;
     _socialId = null;
-  }
+    _avatar = null;
+    _gender = null;
+    _location = null;
+    _bio = null;
+    _firstName = null;
+    _lastName = null;
+    _phone = null;
+    _street = null;
+    _country = null;
+    _postalCode = null;
+    _dob = null;
+    _hobbies = null;
+    _friendInfo = null;
+    _musicPreferences = null;
+}
 
-  Future<bool> loadProfile(String? token) async {
-    return await execute(() async {
+  Future<bool> loadProfile(String? token) async{
+    try{
+
+      _isLoading = true;
+      _errorMessage = null;
       resetValues();
+      notifyListeners();
+
       final data = await _apiService.getUser(token);
 
       _userId = data['id'];
@@ -61,52 +124,291 @@ class ProfileProvider with ChangeNotifier, BaseProvider {
       _isPasswordUsable = data['is_password_usable'] as bool;
       
       final hasSocialAccount = data['has_social_account'] as bool;
-      if (hasSocialAccount) {
+      if (hasSocialAccount){
         final social = data['social'] as Map<String, dynamic>;
         _socialType = social['type'];
         _socialEmail = social['social_email'];
         _socialName = social['social_name'];
         _socialId = social['social_id'];
       }
-    }) != null;
+
+      final profilePublic = await _profileApiService.getProfilePublic(token);
+      _avatar = profilePublic['avatar'];
+      _gender = profilePublic['gender'];
+      _location = profilePublic['location'];
+      _bio = profilePublic['bio'];
+
+      final profilePrivate = await _profileApiService.getProfilePrivate(token);
+      _firstName = profilePrivate['first_name'];
+      _lastName = profilePrivate['last_name'];
+      _phone = profilePrivate['phone'];
+      _street = profilePrivate['street'];
+      _country = profilePrivate['country'];
+      _postalCode = profilePrivate['postal_code'];
+
+      final profileFriend = await _profileApiService.getProfileFriend(token);
+      _hobbies = profileFriend ['hobbies'];
+      _friendInfo = profileFriend ['friend_info'];
+      final dobDb = profileFriend ['dob'];
+      if (dobDb != null){
+        _dob = DateTime.parse(dobDb);
+      }
+
+      final profileMusic = await _profileApiService.getProfileMusic(token);
+      _musicPreferences = profileMusic['music_preferences'];
+
+      _isLoading = false;
+      notifyListeners();
+      return true;
+    }
+    catch (e) {
+      _errorMessage = e.toString();
+      _isLoading = false;
+      notifyListeners();
+      return false;
+    }
   }
+
 
   Future<bool> userPasswordChange(String? token, String currentPassword, String newPassword) async {
-    return await execute(() async {
+    try{
+    
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
       await _apiService.userPasswordChange(token, currentPassword, newPassword);
-    }) != null;
+
+      _isLoading = false;
+      notifyListeners();
+      return true;
+    }
+    catch (e) {
+      _errorMessage = e.toString();
+      _isLoading = false;
+      notifyListeners();
+      return false;
+    }
   }
 
+
   Future<bool> facebookLink(String? token) async {
-    return await execute(() async {
-      final LoginResult result = await FacebookAuth.instance.login();
-      if (result.status == LoginStatus.success) {
-        final fbAccessToken = result.accessToken!.tokenString;
-        await _apiService.facebookLink(token, fbAccessToken);
-      } else {
-        throw Exception("Facebook login failed!");
+    try{
+        _isLoading = true;
+        _errorMessage = null;
+        notifyListeners();
+
+        final LoginResult result = await FacebookAuth.instance.login();
+        if (result.status == LoginStatus.success) {
+          final fbAccessToken = result.accessToken!.tokenString;
+
+          await _apiService.facebookLink(token, fbAccessToken);
+
+          _isLoading = false;
+          notifyListeners();
+          return true;
+        }
+        else {
+          _errorMessage = "Facebook login failed !";
+          _isLoading = false;
+          notifyListeners();
+          return false;
+        }
+      } catch (e) {
+        _errorMessage = e.toString();
+        _isLoading = false;
+        notifyListeners();
+        return false;
       }
-    }) != null;
   }
 
   Future<bool> googleLinkWeb(String? token, GoogleSignInUserData? account) async {
-    return await execute(() async {
+    try{
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
       var idToken = account?.idToken;
-      if (idToken == null) throw Exception("Google login failed!");
+
+      if (idToken == null) {
+        _errorMessage = "Google login failed !";
+        _isLoading = false;
+        notifyListeners();
+        return false;
+      }
+
       await _apiService.googleLink('web', token, idToken);
-    }) != null;
+      
+      _isLoading = false;
+      notifyListeners();
+      return true;
+
+    } catch (e) {
+      _errorMessage = e.toString();
+      _isLoading = false;
+      notifyListeners();
+      return false;
+    }
+
   }
 
   Future<bool> googleLinkApp(String? token) async {
-    return await execute(() async {
+    try{
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
       final user = await googleSignIn?.signIn();
-      if (user == null) throw Exception("Google login failed!");
+
+      if (user == null) {
+        _errorMessage = "Google login failed !";
+        _isLoading = false;
+        notifyListeners();
+        return false;
+      }
 
       final auth = await user.authentication;
       final idToken = auth.idToken;
-      if (idToken == null) throw Exception("Google login failed!");
+
+      if (idToken == null) {
+        _errorMessage = "Google login failed !";
+        _isLoading = false;
+        notifyListeners();
+        return false;
+      }
 
       await _apiService.googleLink('app', token, idToken);
-    }) != null;
+      
+      _isLoading = false;
+      notifyListeners();
+      return true;
+
+    } catch (e) {
+        _errorMessage = e.toString();
+        _isLoading = false;
+        notifyListeners();
+        return false;
+    }
   }
+
+  Future<bool> updateAvatar(String? token, String? avatarBase64, String? mimeType) async {
+    try{
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      await _profileApiService.updateAvatar(token, avatarBase64, mimeType);
+      
+      _isLoading = false;
+      notifyListeners();
+      return true;
+
+    } catch (e) {
+        _errorMessage = e.toString();
+        _isLoading = false;
+        notifyListeners();
+        return false;
+    }
+  }
+
+  Future<bool> updatePublicBasic(String? token, String? gender, String? location) async {
+    try{
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      await _profileApiService.updatePublicBasic(token, gender, location);
+      
+      _isLoading = false;
+      notifyListeners();
+      return true;
+
+    } catch (e) {
+        _errorMessage = e.toString();
+        _isLoading = false;
+        notifyListeners();
+        return false;
+    }
+  }
+
+  Future<bool> updatePublicBio(String? token, String? bio) async {
+    try{
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      await _profileApiService.updatePublicBio(token, bio);
+      
+      _isLoading = false;
+      notifyListeners();
+      return true;
+
+    } catch (e) {
+        _errorMessage = e.toString();
+        _isLoading = false;
+        notifyListeners();
+        return false;
+    }
+  }
+
+  Future<bool> updatePrivateInfo(String? token, String? firstName, String? lastName, String? phone, String? street, String? country, String? postalCode) async {
+    try{
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      await _profileApiService.updatePrivateInfo(token, firstName, lastName, phone, street, country, postalCode);
+      
+      _isLoading = false;
+      notifyListeners();
+      return true;
+
+    } catch (e) {
+        _errorMessage = e.toString();
+        _isLoading = false;
+        notifyListeners();
+        return false;
+    }
+  }
+
+  Future<bool> updateFriendInfo(String? token, String? dob, List<String>? hobbies, String? friendInfo) async {
+    try{
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      await _profileApiService.updateFriendInfo(token, dob, hobbies, friendInfo);
+      
+      _isLoading = false;
+      notifyListeners();
+      return true;
+
+    } catch (e) {
+        _errorMessage = e.toString();
+        _isLoading = false;
+        notifyListeners();
+        return false;
+    }
+  }
+
+  Future<bool> updateMusicPreferences(String? token, List<String>? musicPreferences) async {
+    try{
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      await _profileApiService.updateMusicPreferences(token, musicPreferences);
+      
+      _isLoading = false;
+      notifyListeners();
+      return true;
+
+    } catch (e) {
+        _errorMessage = e.toString();
+        _isLoading = false;
+        notifyListeners();
+        return false;
+    }
+  }
+
 }

--- a/frontend-dart/lib/screens/profile/components/date_picker.dart
+++ b/frontend-dart/lib/screens/profile/components/date_picker.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import './utils.dart';
+
+
+class DatePicker extends StatefulWidget {
+  final String label;
+  final Function(DateTime) onDateSelected;
+  final String? initDate;
+
+  const DatePicker({
+    super.key,
+    required this.label,
+    required this.onDateSelected,
+    required this.initDate,
+  });
+
+  @override
+  State<DatePicker> createState() => _DatePickerState();
+}
+
+class _DatePickerState extends State<DatePicker> {
+  DateTime? _selectedDate;
+  final TextEditingController _dobController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+
+    if (widget.initDate != null){
+        _dobController.text = widget.initDate!;
+    }
+  }
+
+  Future<void> _selectDate() async {
+    DateTime now = DateTime.now();
+    final DateTime? pickedDate = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate ?? now,
+      firstDate: DateTime(1900),
+      lastDate: now,
+    );
+
+    if (pickedDate != null) {
+      setState(() {
+        _selectedDate = pickedDate;
+        _dobController.text = Utils.formatDate(pickedDate);
+      });
+      widget.onDateSelected(pickedDate);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: _dobController,
+      readOnly: true,
+      onTap: _selectDate,
+      decoration: InputDecoration(
+        labelText: widget.label,
+        suffixIcon: Icon(Icons.calendar_today),
+        border: OutlineInputBorder(),
+      ),
+      validator: (value) =>
+          value == null || value.isEmpty ? 'Please select a date' : null,
+    );
+  }
+}

--- a/frontend-dart/lib/screens/profile/components/friend_info_tab_view.dart
+++ b/frontend-dart/lib/screens/profile/components/friend_info_tab_view.dart
@@ -1,0 +1,226 @@
+// lib/screens/profile/components/friend_info_tab_view.dart
+import 'package:flutter/material.dart';
+import '../../../core/app_core.dart';
+import '../../../providers/profile_provider.dart';
+import '../../../providers/auth_provider.dart';
+import 'package:provider/provider.dart';
+import '../../../widgets/common_widgets.dart';
+import './date_picker.dart';
+import './utils.dart';
+
+
+class FriendInfoTabView extends StatefulWidget {
+  const FriendInfoTabView({Key? key}) : super(key: key);
+
+  @override
+  State<FriendInfoTabView> createState() => _FriendInfoTabViewState();
+}
+
+class _FriendInfoTabViewState extends State<FriendInfoTabView> {
+  final _formKey = GlobalKey<FormState>();
+  final _friendInfoController = TextEditingController();
+
+  DateTime? _dob;
+  bool _hobbyValidationError = false;
+  
+  final List<String> _hobbies = [
+    'Sport',
+    'Movie',
+    'Music',
+    'Travel',
+  ];
+  
+  final Map<String, bool> _selectedHobbies = {};
+
+  @override
+  void initState() {
+    super.initState();
+    
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+
+      setState(() {
+        for (var hobby in _hobbies) {
+          _selectedHobbies[hobby] = profileProvider.hobbies?.contains(hobby) ?? false;
+        }
+      });
+
+      if (profileProvider.friendInfo != null) {
+        _friendInfoController.text = profileProvider.friendInfo!;
+      }
+      
+    });
+  }
+
+
+  Future<void> _submit() async {
+    try{
+
+      setState((){
+          _hobbyValidationError = false;
+        });
+    
+      if (!_formKey.currentState!.validate()) return;
+      
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+
+      if (authProvider.token == null) return;
+
+      String dobToSave = "";
+      if (_dob == null) {
+        dobToSave = Utils.formatDate(profileProvider.dob);
+      }
+      dobToSave = Utils.formatDate(_dob);
+
+      List<String> selected = [];
+      for (var key in _selectedHobbies.keys) {
+        if (_selectedHobbies[key] == true) {
+          selected.add(key);
+        }
+      }
+
+      if (selected.isEmpty){
+        setState((){
+          _hobbyValidationError = true;
+        });
+        return;
+      }
+
+      bool success = false;
+      success = await profileProvider.updateFriendInfo(authProvider.token, dobToSave, selected, _friendInfoController.text);
+
+      if (success) {
+        await profileProvider.loadProfile(authProvider.token);
+        CommonWidgets.showSnackBar(context, 'Update successful', isError: false);
+      }
+
+    } catch (e) {
+        CommonWidgets.showSnackBar(context, 'Exception: $e', isError: true );
+        return ;
+      }
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ProfileProvider>(
+      builder: (context, profileProvider, child) {
+
+        return ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            color: AppTheme.surface,
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+                child: Form(
+                key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+
+                    children: [
+
+                    if (profileProvider.hasError) ...[
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.red.withOpacity(0.3)),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.error_outline, color: Colors.red, size: 20),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                profileProvider.errorMessage ?? 'An error occurred',
+                                style: const TextStyle(color: Colors.red, fontSize: 14),
+                              ),
+                            ),  
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+
+                    Text(
+                      'Date of birth',
+                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 16),
+
+                    DatePicker(
+                      label: 'Date of Birth',
+                      initDate: Utils.formatDate(profileProvider.dob),
+                      onDateSelected: (date) {
+                        setState(() => _dob = date);
+                      },
+                    ),
+                    const SizedBox(height: 16),
+
+
+                    Text(
+                      'Hobby',
+                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 16),
+
+                    if (_hobbyValidationError) ...[
+                        Padding(
+                          padding: EdgeInsets.only(left: 16.0),
+                          child: Text(
+                            'Please select at least one hobby.',
+                            style: TextStyle(color: Colors.red, fontSize: 12),
+                        ),
+                      ),
+                    ],
+                    
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: _hobbies.map((hobby) {
+                        return CheckboxListTile(
+                          title: Text(hobby),
+                          value: _selectedHobbies[hobby] ?? false,
+                          onChanged: (bool? value) {
+                            setState(() {
+                              _selectedHobbies[hobby] = value ?? false;
+                            });
+                          },
+                        );
+                      }).toList(),
+                    ),
+                    const SizedBox(height: 16),
+
+                    AppTextField(
+                      controller: _friendInfoController,
+                      labelText: 'Something for friend',
+                      obscureText: false,
+                      minLines: 5,
+                      maxLines: 10,
+                      validator: (v) => v?.isEmpty ?? true ? 'Please enter something for friend' :
+                                v!.length > 500 ? 'Friend info maximum 500 characters' : null,
+                    ),
+                    const SizedBox(height: 24),
+
+                    profileProvider.isLoading
+                    ? const CircularProgressIndicator(color: AppTheme.primary)
+                    : 
+                      ElevatedButton(
+                        onPressed: _submit,
+                        child: Text('Save'),
+                      ),
+                    
+                    ],
+
+                  ),
+                ),
+            ),
+          ),
+        ]
+        );
+      }
+    );
+  }
+}

--- a/frontend-dart/lib/screens/profile/components/music_preference_tab_view.dart
+++ b/frontend-dart/lib/screens/profile/components/music_preference_tab_view.dart
@@ -1,0 +1,187 @@
+// lib/screens/profile/components/music_preference_tab_view.dart
+import 'package:flutter/material.dart';
+import '../../../core/app_core.dart';
+import '../../../providers/profile_provider.dart';
+import '../../../providers/auth_provider.dart';
+import 'package:provider/provider.dart';
+import '../../../widgets/common_widgets.dart';
+
+
+class MusicPreferenceTabView extends StatefulWidget {
+  const MusicPreferenceTabView({Key? key}) : super(key: key);
+
+  @override
+  State<MusicPreferenceTabView> createState() => _MusicPreferenceTabViewState();
+}
+
+class _MusicPreferenceTabViewState extends State<MusicPreferenceTabView> {
+  final _formKey = GlobalKey<FormState>();
+
+  bool _prefsValidationError = false;
+  
+  final List<String> _prefs = [
+    'Classical',
+    'Jazz',
+    'Pop',
+    'Rock',
+    'Rap',
+    'R&B',
+    'Techno',
+  ];
+  
+  final Map<String, bool> _selectedPrefs = {};
+
+  @override
+  void initState() {
+    super.initState();
+    
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+
+      setState(() {
+        for (var pref in _prefs) {
+          _selectedPrefs[pref] = profileProvider.musicPreferences?.contains(pref) ?? false;
+        }
+      });
+      
+    });
+  }
+
+
+  Future<void> _submit() async {
+    try{
+
+      setState((){
+          _prefsValidationError = false;
+      });
+    
+      if (!_formKey.currentState!.validate()) return;
+      
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+
+      if (authProvider.token == null) return;
+
+      List<String> selected = [];
+      for (var key in _selectedPrefs.keys) {
+        if (_selectedPrefs[key] == true) {
+          selected.add(key);
+        }
+      }
+
+      if (selected.isEmpty){
+        setState((){
+          _prefsValidationError = true;
+        });
+        return;
+      }
+
+      bool success = false;
+      success = await profileProvider.updateMusicPreferences(authProvider.token, selected);
+
+      if (success) {
+        await profileProvider.loadProfile(authProvider.token);
+        CommonWidgets.showSnackBar(context, 'Update successful', isError: false);
+      }
+
+    } catch (e) {
+        CommonWidgets.showSnackBar(context, 'Exception: $e', isError: true);
+        return ;
+      }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ProfileProvider>(
+      builder: (context, profileProvider, child) {
+
+        return ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            color: AppTheme.surface,
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+                child: Form(
+                key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+
+                    children: [
+
+                    if (profileProvider.hasError) ...[
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.red.withOpacity(0.3)),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.error_outline, color: Colors.red, size: 20),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                profileProvider.errorMessage ?? 'An error occurred',
+                                style: const TextStyle(color: Colors.red, fontSize: 14),
+                              ),
+                            ),  
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+
+                    Text(
+                      'Music Preferences',
+                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 16),
+
+                    if (_prefsValidationError) ...[
+                        Padding(
+                          padding: EdgeInsets.only(left: 16.0),
+                          child: Text(
+                            'Please select at least one music preference.',
+                            style: TextStyle(color: Colors.red, fontSize: 12),
+                        ),
+                      ),
+                    ],
+                    
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: _prefs.map((pref) {
+                        return CheckboxListTile(
+                          title: Text(pref),
+                          value: _selectedPrefs[pref] ?? false,
+                          onChanged: (bool? value) {
+                            setState(() {
+                              _selectedPrefs[pref] = value ?? false;
+                            });
+                          },
+                        );
+                      }).toList(),
+                    ),
+                    const SizedBox(height: 16),
+
+                    profileProvider.isLoading
+                    ? const CircularProgressIndicator(color: AppTheme.primary)
+                    : 
+                      ElevatedButton(
+                        onPressed: _submit,
+                        child: Text('Save'),
+                      ),
+                    
+                    ],
+
+                  ),
+                ),
+            ),
+          ),
+        ]
+        );
+      }
+    );
+  }
+}

--- a/frontend-dart/lib/screens/profile/components/private_info_tab_view.dart
+++ b/frontend-dart/lib/screens/profile/components/private_info_tab_view.dart
@@ -1,0 +1,263 @@
+// lib/screens/profile/components/private_info_tab_view.dart
+import 'package:flutter/material.dart';
+import '../../../core/app_core.dart';
+import '../../../providers/profile_provider.dart';
+import '../../../providers/auth_provider.dart';
+import 'package:provider/provider.dart';
+import '../../../widgets/common_widgets.dart';
+
+
+class PrivateInfoTabView extends StatefulWidget {
+  const PrivateInfoTabView({Key? key}) : super(key: key);
+
+  @override
+  State<PrivateInfoTabView> createState() => _PrivateInfoTabViewState();
+}
+
+class _PrivateInfoTabViewState extends State<PrivateInfoTabView> {
+  final _formKey = GlobalKey<FormState>();
+  final _lastNameController = TextEditingController();
+  final _firstNameController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _streetController = TextEditingController();
+  final _postalCodeController = TextEditingController();
+  
+  String? _selectedCountry;
+  
+  final List<String> _countries = [
+    'Singapore',
+    'Malaysia',
+    'Indonesia',
+    'Thailand',
+    'United States',
+    'Canada',
+    'United Kingdom',
+    'Australia',
+  ];
+  
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+      
+      if (profileProvider.lastName != null) {
+        _lastNameController.text = profileProvider.lastName!;
+      }
+      if (profileProvider.firstName != null) {
+        _firstNameController.text = profileProvider.firstName!;
+      }
+      if (profileProvider.phone != null) {
+        _phoneController.text = profileProvider.phone!;
+      }
+      if (profileProvider.street != null) {
+        _streetController.text = profileProvider.street!;
+      }
+      if (profileProvider.country != null) {
+        setState(() {
+          _selectedCountry = profileProvider.country;
+        });
+      }
+      if (profileProvider.postalCode != null) {
+        _postalCodeController.text = profileProvider.postalCode!;
+      }
+    });
+  }
+
+  Future<void> _submit() async {
+    try{
+
+      if (!_formKey.currentState!.validate()) return;
+      
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+
+      if (authProvider.token == null) return;
+
+      bool success = false;
+      success = await profileProvider.updatePrivateInfo(authProvider.token, _firstNameController.text, 
+        _lastNameController.text, _phoneController.text, _streetController.text, _selectedCountry, 
+        _postalCodeController.text);
+
+      if (success) {
+        await profileProvider.loadProfile(authProvider.token);
+        CommonWidgets.showSnackBar(context, 'Update successful', isError: false);
+      }
+
+    } catch (e) {
+          CommonWidgets.showSnackBar(context, 'Exception: $e', isError: true);
+          return ;
+        }
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ProfileProvider>(
+      builder: (context, profileProvider, child) {
+
+        return ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            color: AppTheme.surface,
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+                child: Form(
+                key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+
+                    children: [
+
+                    if (profileProvider.hasError) ...[
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.red.withOpacity(0.3)),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.error_outline, color: Colors.red, size: 20),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                profileProvider.errorMessage ?? 'An error occurred',
+                                style: const TextStyle(color: Colors.red, fontSize: 14),
+                              ),
+                            ),  
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+
+                    AppTextField(
+                      controller: _firstNameController,
+                      labelText: 'First name',
+                      obscureText: false,
+                      validator: (v) {
+                        if (v == null || v.isEmpty) {
+                          return 'Please enter your first name';
+                        } else if (v.length > 50) {
+                          return 'First name maximum 50 characters';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+
+                    AppTextField(
+                      controller: _lastNameController,
+                      labelText: 'Last name',
+                      obscureText: false,
+                      validator: (v) {
+                        if (v == null || v.isEmpty) {
+                          return 'Please enter your last name';
+                        } else if (v.length > 50) {
+                          return 'Last name maximum 50 characters';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+
+                    AppTextField(
+                      controller: _phoneController,
+                      labelText: 'Phone number',
+                      obscureText: false,
+                      validator: (v) {
+                        if (v == null || v.isEmpty) {
+                          return 'Please enter a phone number';
+                        } else if (!RegExp(r'^\d+$').hasMatch(v)) {
+                          return 'Phone number must contain only digits';
+                        } else if (v.length > 10) {
+                          return 'Phone number maximum 10 digits';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+
+                    AppTextField(
+                      controller: _streetController,
+                      labelText: 'Street/Block/Unit/City',
+                      obscureText: false,
+                      minLines: 3,
+                      maxLines: 5,
+                      validator: (v) {
+                        if (v == null || v.isEmpty) {
+                          return 'Please enter your address';
+                        } else if (v.length > 100) {
+                          return 'Street/Block/Unit/City maximum 100 characters';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+
+                    DropdownButtonFormField<String>(
+                      value: _selectedCountry,
+                      decoration: InputDecoration(
+                        labelText: 'Country',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: _countries.map((country) {
+                        return DropdownMenuItem<String>(
+                          value: country,
+                          child: Text(country),
+                        );
+                      }).toList(),
+                      onChanged: (value) {
+                        setState(() {
+                          _selectedCountry = value;
+                        });
+                      },
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Please select a country';
+                        }
+                        return null;
+                      },
+                  ),
+                  const SizedBox(height: 16),
+
+                  AppTextField(
+                      controller: _postalCodeController,
+                      labelText: 'Postal Code',
+                      obscureText: false,
+                      validator: (v) {
+                        if (v == null || v.isEmpty) {
+                          return 'Please enter a postal code';
+                        } else if (!RegExp(r'^\d+$').hasMatch(v)) {
+                          return 'Postal code must contain only digits';
+                        } else if (v.length > 10) {
+                          return 'Postal code maximum 10 digits';
+                        }
+                        return null;
+                      },
+                  ),
+                  const SizedBox(height: 16),
+
+                  profileProvider.isLoading
+                    ? const CircularProgressIndicator(color: AppTheme.primary)
+                    : 
+                      ElevatedButton(
+                        onPressed: _submit,
+                        child: Text('Save'),
+                      ),
+                    
+                    ],
+
+                  ),
+                ),
+            ),
+          ),
+        ]
+        );
+      }
+    );
+  }
+}

--- a/frontend-dart/lib/screens/profile/components/public_avatar_tab_view.dart
+++ b/frontend-dart/lib/screens/profile/components/public_avatar_tab_view.dart
@@ -1,0 +1,185 @@
+// lib/screens/profile/components/public_avatar_tab_view.darts
+import 'package:flutter/material.dart';
+import '../../../core/app_core.dart';
+import 'dart:convert';
+import 'package:image_picker/image_picker.dart';
+import 'dart:typed_data';
+import '../../../providers/profile_provider.dart';
+import '../../../providers/auth_provider.dart';
+import 'package:provider/provider.dart';
+import '../../../widgets/common_widgets.dart';
+import 'package:mime/mime.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+
+class PublicAvatarTabView extends StatefulWidget {
+  const PublicAvatarTabView({Key? key}) : super(key: key);
+
+  @override
+  State<PublicAvatarTabView> createState() => _PublicAvatarTabViewState();
+}
+
+class _PublicAvatarTabViewState extends State<PublicAvatarTabView> {
+  XFile? _imageFile;
+  String? _imageBase64;
+  Uint8List? _imageBytes;
+  String? _mimeType;
+
+  final String _baseUrl = dotenv.env['API_BASE_URL'] ?? AppConstants.defaultApiBaseUrl;
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: ImageSource.gallery);
+
+    if (picked != null) {
+
+      if(!await isValidImageFile(picked)) {
+          CommonWidgets.showSnackBar(context, 'Error: Need image JPEG or PNG', isError: true);
+        return ;
+      }
+
+      final mimeType = await getMimeType(picked);
+      final bytes = await picked.readAsBytes();
+
+      setState(() {
+        _imageBytes = bytes;
+        _imageFile = picked;
+        _imageBase64 = base64Encode(bytes);
+        _mimeType = mimeType;
+
+      });
+    }
+  }
+
+  Future<bool> isValidImageFile(XFile file) async {
+    final ext = file.name.split('.').last.toLowerCase();
+    if (!(ext == 'jpg' || ext == 'jpeg' || ext == 'png')) {
+      return false;
+    }
+
+    final bytes = await file.readAsBytes();
+    final mimeType = lookupMimeType(file.name, headerBytes: bytes);
+    return mimeType == 'image/jpeg' || mimeType == 'image/png';
+  }
+
+  Future<String?> getMimeType(XFile file) async {
+    Uint8List bytes = await file.readAsBytes();
+
+    final mimeType = lookupMimeType(file.name, headerBytes: bytes);
+    return mimeType;
+  }
+
+  Future<void> clear() async{
+      setState(() {
+        _imageFile = null;
+        _imageBytes = null;
+        _imageBase64 = null;
+        _mimeType = null;
+      });
+  }
+
+
+  Future<void> _uploadImage() async {
+    try{
+
+      if (_imageFile == null) return;
+
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+
+      bool success = false;
+      success = await profileProvider.updateAvatar(authProvider.token, _imageBase64, _mimeType);
+
+      if (success) {
+
+        await clear();
+        await profileProvider.loadProfile(authProvider.token);
+        CommonWidgets.showSnackBar(context, 'Update successful', isError: false);
+      }
+
+  } catch (e) {
+        CommonWidgets.showSnackBar(context, 'Exception: $e', isError: true);
+        return ;
+      }
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ProfileProvider>(
+      builder: (context, profileProvider, child) {
+
+      return ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            color: AppTheme.surface,
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                children: [
+
+                  if (profileProvider.hasError) ...[
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.red.withOpacity(0.3)),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.error_outline, color: Colors.red, size: 20),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                profileProvider.errorMessage ?? 'An error occurred',
+                                style: const TextStyle(color: Colors.red, fontSize: 14),
+                              ),
+                            ),  
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                  ],
+
+                  CircleAvatar(
+                    radius: 50,
+                    backgroundColor: Colors.grey[300],
+                    backgroundImage: _imageBytes != null
+                        ? MemoryImage(_imageBytes!)
+                        : (profileProvider.avatar != null
+                            ? NetworkImage('$_baseUrl${profileProvider.avatar!}')
+                            : null),
+                    child: _imageBytes == null && profileProvider.avatar == null
+                        ? Icon(Icons.person, size: 50)
+                        : null,
+                  ),
+                  const SizedBox(height: 16),
+
+                  ElevatedButton(
+                    onPressed: _pickImage,
+                    child: Text('Select Image'),
+                  ),
+                  const SizedBox(height: 16),
+
+                  if (_imageBytes != null) ...[
+                    ElevatedButton(
+                      onPressed: _uploadImage,
+                      child: Text('Save'),
+                    ),
+                  ],
+
+                  const SizedBox(height: 16),
+
+                ],
+              ),
+            ),
+          ),
+        ]
+      );
+
+      }
+    );
+  }
+}

--- a/frontend-dart/lib/screens/profile/components/public_basic_tab_view.dart
+++ b/frontend-dart/lib/screens/profile/components/public_basic_tab_view.dart
@@ -1,0 +1,188 @@
+// lib/screens/profile/components/public_basic_tab_view.darts
+import 'package:flutter/material.dart';
+import '../../../core/app_core.dart';
+import '../../../providers/profile_provider.dart';
+import '../../../providers/auth_provider.dart';
+import 'package:provider/provider.dart';
+import '../../../widgets/common_widgets.dart';
+
+
+class PublicBasicTabView extends StatefulWidget {
+  const PublicBasicTabView({Key? key}) : super(key: key);
+
+  @override
+  State<PublicBasicTabView> createState() => _PublicBasicTabViewState();
+}
+
+class _PublicBasicTabViewState extends State<PublicBasicTabView> {
+  final _formKey = GlobalKey<FormState>();
+  final _locationController = TextEditingController();
+  
+  String? _gender;
+  bool _genderValidationError = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+
+      if (profileProvider.gender != null){
+        setState(() {
+          _gender = profileProvider.gender;
+        });
+      }
+
+      if (profileProvider.location != null) {
+        _locationController.text = profileProvider.location!;
+      }
+
+    });
+  }
+
+  Future<void> _submit() async {
+    try{
+      
+      setState((){
+          _genderValidationError = false;
+      });
+
+      if (!_formKey.currentState!.validate()) return;
+      
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+
+      if (authProvider.token == null) return;
+
+      if (_gender == null){
+        setState((){
+          _genderValidationError = true;
+        });
+        return;
+      }
+
+      bool success = false;
+      success = await profileProvider.updatePublicBasic(authProvider.token, _gender, _locationController.text);
+
+      if (success) {
+        await profileProvider.loadProfile(authProvider.token);
+        CommonWidgets.showSnackBar(context, 'Update successful', isError: false);
+      }
+      
+    } catch (e) {
+        CommonWidgets.showSnackBar(context, 'Exception: $e', isError: true);
+        return ;
+      }  
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ProfileProvider>(
+      builder: (context, profileProvider, child) {
+
+        return ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            color: AppTheme.surface,
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+                child: Form(
+                key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+
+                    children: [
+
+                    if (profileProvider.hasError) ...[
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.red.withOpacity(0.3)),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.error_outline, color: Colors.red, size: 20),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                profileProvider.errorMessage ?? 'An error occurred',
+                                style: const TextStyle(color: Colors.red, fontSize: 14),
+                              ),
+                            ),  
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+
+                    const Text(
+                      'Gender',
+                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 16),
+                    
+                    if (_genderValidationError) ...[
+                        Padding(
+                          padding: EdgeInsets.only(left: 16.0),
+                          child: Text(
+                            'Please select gender',
+                            style: TextStyle(color: Colors.red, fontSize: 12),
+                        ),
+                      ),
+                    ],
+
+                    RadioListTile<String>(
+                      title: const Text('Male'),
+                      value: 'male',
+                      groupValue: _gender,
+                      onChanged: (value) {
+                        setState(() {
+                          _gender = value;
+                        });
+                      },
+                    ),
+                    RadioListTile<String>(
+                      title: const Text('Female'),
+                      value: 'female',
+                      groupValue: _gender,
+                      onChanged: (value) {
+                        setState(() {
+                          _gender = value;
+                        });
+                      },
+                    ),
+                    const SizedBox(height: 16),
+
+                    AppTextField(
+                    controller: _locationController,
+                    labelText: 'Current Location',
+                    obscureText: false,
+                    validator: (v) => v?.isEmpty ?? true ? 'Please enter a location' : 
+                              v!.length > 50 ? 'Location maximum 50 characters' : null,
+                    ),
+                    const SizedBox(height: 24),
+
+                    profileProvider.isLoading
+                      ? const CircularProgressIndicator(color: AppTheme.primary)
+                      : 
+                        ElevatedButton(
+                          onPressed: _submit,
+                          child: Text('Save'),
+                        ),
+                    ],
+
+                  ),
+                ),
+            ),
+          ),
+        ]
+        );
+
+      }
+    );
+  }
+}

--- a/frontend-dart/lib/screens/profile/components/public_bio_tab_view.dart
+++ b/frontend-dart/lib/screens/profile/components/public_bio_tab_view.dart
@@ -1,0 +1,137 @@
+// lib/screens/profile/components/public_bio_tab_view.darts
+import 'package:flutter/material.dart';
+import '../../../core/app_core.dart';
+import '../../../providers/profile_provider.dart';
+import '../../../providers/auth_provider.dart';
+import 'package:provider/provider.dart';
+import '../../../widgets/common_widgets.dart';
+
+
+class PublicBioTabView extends StatefulWidget {
+  const PublicBioTabView({Key? key}) : super(key: key);
+
+  @override
+  State<PublicBioTabView> createState() => _PublicBioTabViewState();
+}
+
+class _PublicBioTabViewState extends State<PublicBioTabView> {
+  final _formKey = GlobalKey<FormState>();
+  final _bioController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+      if (profileProvider.bio != null) {
+        _bioController.text = profileProvider.bio!;
+      }
+    });
+  }
+
+
+  Future<void> _submit() async {
+    try{
+
+      if (!_formKey.currentState!.validate()) return;
+      
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+
+      if (authProvider.token == null) return;
+
+      bool success = false;
+      success = await profileProvider.updatePublicBio(authProvider.token,_bioController.text);
+
+      if (success) {
+        await profileProvider.loadProfile(authProvider.token);
+        CommonWidgets.showSnackBar(context, 'Update successful', isError: false);
+      }
+      
+    } catch (e) {
+        CommonWidgets.showSnackBar(context, 'Exception: $e', isError: true);
+        return ;
+      }  
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ProfileProvider>(
+      builder: (context, profileProvider, child) {
+
+        return ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            color: AppTheme.surface,
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+                child: Form(
+                key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+
+                    children: [
+
+                    if (profileProvider.hasError) ...[
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.red.withOpacity(0.3)),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.error_outline, color: Colors.red, size: 20),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                profileProvider.errorMessage ?? 'An error occurred',
+                                style: const TextStyle(color: Colors.red, fontSize: 14),
+                              ),
+                            ),  
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                    ],    
+
+                    Text(
+                      'Bio',
+                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 16),
+
+                    AppTextField(
+                    controller: _bioController,
+                    labelText: 'Something about yourself',
+                    obscureText: false,
+                    minLines: 5,
+                    maxLines: 10,
+                    validator: (v) => v?.isEmpty ?? true ? 'Please enter a bio' : 
+                              v!.length > 500 ? 'Bio maximum 500 characters' : null,
+                    ),
+                    const SizedBox(height: 24),
+
+                    profileProvider.isLoading
+                      ? const CircularProgressIndicator(color: AppTheme.primary)
+                      : 
+                        ElevatedButton(
+                          onPressed: _submit,
+                          child: Text('Save'),
+                        ),
+                    ],
+
+                  ),
+                ),
+            ),
+          ),
+        ]
+        );
+
+      }
+    );
+  }
+}

--- a/frontend-dart/lib/screens/profile/components/utils.dart
+++ b/frontend-dart/lib/screens/profile/components/utils.dart
@@ -1,0 +1,12 @@
+import 'package:intl/intl.dart';
+
+class Utils {
+
+  static String formatDate(DateTime? date) {
+    if (date != null) {
+      return DateFormat('yyyy-MM-dd').format(date);
+    }
+    return '';
+  }
+
+}

--- a/frontend-dart/lib/screens/profile/friend_info_screen.dart
+++ b/frontend-dart/lib/screens/profile/friend_info_screen.dart
@@ -1,0 +1,53 @@
+// lib/screens/profile/friend_info_screen.dart
+import 'package:flutter/material.dart';
+import '../../core/app_core.dart';
+import 'components/friend_info_tab_view.dart';
+
+
+class FriendInfoScreen extends StatefulWidget {
+  const FriendInfoScreen({Key? key}) : super(key: key);
+
+  @override
+  State<FriendInfoScreen> createState() => _FriendInfoScreenState();
+}
+
+class _FriendInfoScreenState extends State<FriendInfoScreen> with TickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 1, vsync: this);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      appBar: AppBar(
+        backgroundColor: AppTheme.background,
+        title: const Text('Friend Info'),
+        bottom: TabBar(
+          controller: _tabController,
+          labelColor: AppTheme.primary,
+          unselectedLabelColor: Colors.grey,
+          tabs: [
+            Tab(text: 'Friend Info'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          FriendInfoTabView(),
+        ],
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+}

--- a/frontend-dart/lib/screens/profile/music_preference_screen.dart
+++ b/frontend-dart/lib/screens/profile/music_preference_screen.dart
@@ -1,0 +1,53 @@
+// lib/screens/profile/music_preference_screen.dart
+import 'package:flutter/material.dart';
+import '../../core/app_core.dart';
+import 'components/music_preference_tab_view.dart';
+
+
+class MusicPreferenceScreen extends StatefulWidget {
+  const MusicPreferenceScreen({Key? key}) : super(key: key);
+
+  @override
+  State<MusicPreferenceScreen> createState() => _MusicPreferenceScreenState();
+}
+
+class _MusicPreferenceScreenState extends State<MusicPreferenceScreen> with TickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 1, vsync: this);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      appBar: AppBar(
+        backgroundColor: AppTheme.background,
+        title: const Text('Music Preference'),
+        bottom: TabBar(
+          controller: _tabController,
+          labelColor: AppTheme.primary,
+          unselectedLabelColor: Colors.grey,
+          tabs: [
+            Tab(text: 'Music Preference'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          MusicPreferenceTabView(),
+        ],
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+}

--- a/frontend-dart/lib/screens/profile/private_info_screen.dart
+++ b/frontend-dart/lib/screens/profile/private_info_screen.dart
@@ -1,0 +1,53 @@
+// lib/screens/profile/private_info_screen.dart
+import 'package:flutter/material.dart';
+import '../../core/app_core.dart';
+import 'components/private_info_tab_view.dart';
+
+
+class PrivateInfoScreen extends StatefulWidget {
+  const PrivateInfoScreen({Key? key}) : super(key: key);
+
+  @override
+  State<PrivateInfoScreen> createState() => _PrivateInfoScreenState();
+}
+
+class _PrivateInfoScreenState extends State<PrivateInfoScreen> with TickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 1, vsync: this);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      appBar: AppBar(
+        backgroundColor: AppTheme.background,
+        title: const Text('Private Info'),
+        bottom: TabBar(
+          controller: _tabController,
+          labelColor: AppTheme.primary,
+          unselectedLabelColor: Colors.grey,
+          tabs: [
+            Tab(text: 'Private Info'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          PrivateInfoTabView(),
+        ],
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+}

--- a/frontend-dart/lib/screens/profile/profile_screen.dart
+++ b/frontend-dart/lib/screens/profile/profile_screen.dart
@@ -1,7 +1,6 @@
 // lib/screens/profile/profile_screen.dart
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../../providers/auth_provider.dart';
 import '../../providers/profile_provider.dart';
 import '../../core/app_core.dart';
 import '../../widgets/common_widgets.dart';
@@ -9,6 +8,10 @@ import '../../utils/dialog_utils.dart';
 import '../base_screen.dart';
 import 'user_password_change_screen.dart';
 import 'social_network_link_screen.dart';
+import '../profile/public_info_screen.dart';
+import '../profile/private_info_screen.dart';
+import '../profile/friend_info_screen.dart';
+import '../profile/music_preference_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
   final bool isEmbedded; 
@@ -140,25 +143,45 @@ class _ProfileScreenState extends BaseScreen<ProfileScreen> {
           icon: Icons.public,
           title: 'Public Information', 
           subtitle: 'Information visible to everyone',
-          onTap: () => _showEditInformationDialog('public'),
+          onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => PublicInfoScreen(),
+                  ),
+                )
         ),
         SettingsItem(
           icon: Icons.people,
           title: 'Friends Information',
           subtitle: 'Information visible to friends only',
-          onTap: () => _showEditInformationDialog('friends'),
+          onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => FriendInfoScreen(),
+                  ),
+                )
         ),
         SettingsItem(
           icon: Icons.lock,
           title: 'Private Information',
           subtitle: 'Information visible only to you',
-          onTap: () => _showEditInformationDialog('private'),
+          onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => PrivateInfoScreen(),
+                  ),
+                )
         ),
         SettingsItem(
           icon: Icons.music_note,
           title: 'Music Preferences',
           subtitle: 'Your music tastes and preferences',
-          onTap: _showMusicPreferencesDialog,
+          onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => MusicPreferenceScreen(),
+                  ),
+                )
         ),
       ],
     );

--- a/frontend-dart/lib/screens/profile/public_info_screen.dart
+++ b/frontend-dart/lib/screens/profile/public_info_screen.dart
@@ -1,0 +1,59 @@
+// lib/screens/profile/public_info_screen.dart
+import 'package:flutter/material.dart';
+import '../../core/app_core.dart';
+import 'components/public_avatar_tab_view.dart';
+import 'components/public_basic_tab_view.dart';
+import 'components/public_bio_tab_view.dart';
+
+
+class PublicInfoScreen extends StatefulWidget {
+  const PublicInfoScreen({Key? key}) : super(key: key);
+
+  @override
+  State<PublicInfoScreen> createState() => _PublicInfoScreenState();
+}
+
+class _PublicInfoScreenState extends State<PublicInfoScreen> with TickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      appBar: AppBar(
+        backgroundColor: AppTheme.background,
+        title: const Text('Public Info'),
+        bottom: TabBar(
+          controller: _tabController,
+          labelColor: AppTheme.primary,
+          unselectedLabelColor: Colors.grey,
+          tabs: [
+            Tab(text: 'Avatar'),
+            Tab(text: 'Basic'),
+            Tab(text: 'Bio'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          PublicAvatarTabView(),
+          PublicBasicTabView(),
+          PublicBioTabView(),
+        ],
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+}

--- a/frontend-dart/lib/services/api_service.dart
+++ b/frontend-dart/lib/services/api_service.dart
@@ -221,7 +221,7 @@ class ApiService {
 
   Future<Map<String, dynamic>> getUser(String? token) async {
     return _handleRequest(
-      () => http.get(Uri.parse('$_baseUrl/users/profile/'), headers: _getHeaders(token)),
+      () => http.get(Uri.parse('$_baseUrl/users/get_user/'), headers: _getHeaders(token)),
       (data) => data,
     );
   }
@@ -229,11 +229,11 @@ class ApiService {
   Future<void> userPasswordChange(String? token, String currentPassword, String newPassword) async {
     await _handleRequest(
       () => http.post(
-        Uri.parse('$_baseUrl/users/change_password/'),
+        Uri.parse('$_baseUrl/users/user_password_change/'),
         headers: _getHeaders(token),
         body: json.encode({
-          'current_password': currentPassword,
-          'new_password': newPassword,
+          'currentPassword': currentPassword,
+          'newPassword': newPassword,
         }),
       ),
       (_) => null,

--- a/frontend-dart/lib/services/profile_api_service.dart
+++ b/frontend-dart/lib/services/profile_api_service.dart
@@ -1,0 +1,171 @@
+// lib/services/profile_api_service.dart
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import '../core/app_core.dart';
+
+
+class ProfileApiService {
+  static final ProfileApiService _instance = ProfileApiService._internal();
+  factory ProfileApiService() => _instance;
+  ProfileApiService._internal();
+
+  final String _baseUrl = dotenv.env['API_BASE_URL'] ?? AppConstants.defaultApiBaseUrl;
+  
+  Map<String, String> _getHeaders([String? token]) => {
+    'Content-Type': AppConstants.contentTypeJson,
+    if (token != null) 'Authorization': '${AppConstants.authorizationPrefix} $token',
+  };
+
+  Future<T> _handleRequest<T>(
+    Future<http.Response> Function() request,
+    T Function(Map<String, dynamic>) parser,
+  ) async {
+    try {
+      final response = await request();
+      if (response.statusCode >= 400) {
+        String errorMessage;
+        try {
+          final errorData = json.decode(response.body);
+          errorMessage = errorData['error'] ?? errorData['detail'] ?? '${AppStrings.error}: ${response.statusCode}';
+        } catch (e) {
+          errorMessage = '${AppStrings.error}: ${response.statusCode}';
+        }
+        throw ApiException(errorMessage);
+      }
+      final data = json.decode(response.body);
+      return parser(data);
+    } on SocketException {
+      throw ApiException(AppStrings.connectionErrorMessage);
+    } catch (e) {
+      if (e is ApiException) rethrow;
+      throw ApiException(e.toString());
+    }
+  }
+
+  Future<Map<String, dynamic>> updateAvatar(String? token, String? avatarBase64, String? mimeType) async {
+    return _handleRequest(
+      () => http.post(
+        Uri.parse('$_baseUrl/profile/public/update/'),
+        headers: _getHeaders(token),
+        body: json.encode({'avatarBase64': avatarBase64, 'mimeType': mimeType}),
+      ),
+      (data) => data,
+    );
+  }
+
+  Future<Map<String, dynamic>> getProfilePublic(String? token) async {
+    return _handleRequest(
+        () => http.get(
+          Uri.parse('$_baseUrl/profile/public/'),
+          headers: _getHeaders(token),
+        ),
+        (data) => data,
+      );
+  }
+
+  Future<Map<String, dynamic>> updatePublicBasic(String? token, String? gender, String? location) async {
+      return _handleRequest(
+        () => http.post(
+          Uri.parse('$_baseUrl/profile/public/update/'),
+          headers: _getHeaders(token),
+          body: json.encode({'gender': gender, 'location': location}),
+        ),
+        (data) => data,
+      );
+  }
+
+  Future<Map<String, dynamic>> updatePublicBio(String? token, String? bio) async {
+      return _handleRequest(
+        () => http.post(
+          Uri.parse('$_baseUrl/profile/public/update/'),
+          headers: _getHeaders(token),
+          body: json.encode({'bio': bio}),
+        ),
+        (data) => data,
+      );
+  }
+
+  Future<Map<String, dynamic>> updatePrivateInfo(String? token, String? firstName, String? lastName, String? phone, String? street, String? country, String? postalCode) async {
+      return _handleRequest(
+        () => http.post(
+          Uri.parse('$_baseUrl/profile/private/update/'),
+          headers: _getHeaders(token),
+          body: json.encode({'firstName': firstName, 
+                             'lastName': lastName,
+                             'phone': phone,
+                             'street': street,
+                             'country': country,
+                             'postalCode': postalCode,
+                            }),
+        ),
+        (data) => data,
+      );
+  }
+
+  Future<Map<String, dynamic>> getProfilePrivate(String? token) async {
+    return _handleRequest(
+        () => http.get(
+          Uri.parse('$_baseUrl/profile/private/'),
+          headers: _getHeaders(token),
+        ),
+        (data) => data,
+      );
+  }
+
+  Future<Map<String, dynamic>> updateFriendInfo(String? token, String? dob, List<String>? hobbies, String? friendInfo) async {
+      return _handleRequest(
+        () => http.post(
+          Uri.parse('$_baseUrl/profile/friend/update/'),
+          headers: _getHeaders(token),
+          body: json.encode({'dob': dob,
+                             'hobbies': hobbies,
+                             'friendInfo': friendInfo,
+                            }),
+        ),
+        (data) => data,
+      );
+  }
+
+  Future<Map<String, dynamic>> getProfileFriend(String? token) async {
+    return _handleRequest(
+        () => http.get(
+          Uri.parse('$_baseUrl/profile/friend/'),
+          headers: _getHeaders(token),
+        ),
+        (data) => data,
+      );
+  }
+
+  Future<Map<String, dynamic>> updateMusicPreferences(String? token, List<String>? musicPreferences) async {
+      return _handleRequest(
+        () => http.post(
+          Uri.parse('$_baseUrl/profile/music/update/'),
+          headers: _getHeaders(token),
+          body: json.encode({'musicPreferences': musicPreferences,
+                            }),
+        ),
+        (data) => data,
+      );
+  }
+
+  Future<Map<String, dynamic>> getProfileMusic(String? token) async {
+    return _handleRequest(
+        () => http.get(
+          Uri.parse('$_baseUrl/profile/music/'),
+          headers: _getHeaders(token),
+        ),
+        (data) => data,
+      );
+  }
+
+
+}
+
+class ApiException implements Exception {
+  final String message;
+  ApiException(this.message);
+  @override
+  String toString() => message;
+}

--- a/frontend-dart/lib/widgets/common_widgets.dart
+++ b/frontend-dart/lib/widgets/common_widgets.dart
@@ -519,7 +519,7 @@ class AppTextField extends StatelessWidget {
       controller: controller,
       obscureText: obscureText,
       validator: validator,
-      minLines: maxLines,
+      minLines: minLines,
       maxLines: maxLines,
       onChanged: onChanged,
       style: const TextStyle(color: Colors.white),

--- a/frontend-dart/lib/widgets/common_widgets.dart
+++ b/frontend-dart/lib/widgets/common_widgets.dart
@@ -496,6 +496,7 @@ class AppTextField extends StatelessWidget {
   final IconData? prefixIcon;
   final bool obscureText;
   final String? Function(String?)? validator;
+  final int minLines;      
   final int maxLines;
   final ValueChanged<String>? onChanged;
 
@@ -507,6 +508,7 @@ class AppTextField extends StatelessWidget {
     this.prefixIcon,
     this.obscureText = false,
     this.validator,
+    this.minLines = 1,
     this.maxLines = 1,
     this.onChanged,
   }) : super(key: key);
@@ -517,6 +519,7 @@ class AppTextField extends StatelessWidget {
       controller: controller,
       obscureText: obscureText,
       validator: validator,
+      minLines: maxLines,
       maxLines: maxLines,
       onChanged: onChanged,
       style: const TextStyle(color: Colors.white),

--- a/frontend-dart/pubspec.yaml
+++ b/frontend-dart/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   google_sign_in_platform_interface: ^2.5.0
   js: ^0.6.7
   image_picker: ^1.1.2
+  mime: ^2.0.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Backend:
Add apps.profile
Add models - ProfilePublic, ProfilePrivate, ProfileFriend, ProfileMusic, with some initial fields to handle the requirements, additional valid fields can be added when needed, just let me know.
Add necessary paths in the urls.py.
Add necessary views to process the api request.
Modify core/settings.py, core/urls.py - with MEDIA_URL, MEDIA_ROOT and urls path settings to allow static access to image file(User avatar).
Add a folder to /apps/avatars to save avatar image uploaded.

Frontend:
Add service/profile_api_service.dart - ProfileApiService to handle the api calls to backend for updating/retrieval of all the profile models.
Modify profile_screen.dart to access the different profile screen - PublicInfoScreen, PrivateInfoScreen, FriendInfoScreen, MusicPreferenceScreen.
Modify profile_provider.dart to retrieve the profile info from the backend, and provide the info to the screen for display and allow updates to the backend.
Modify common_widgets.dart - AppTextField, add minLines to allow multiple rows.
Add various profile tab screens in the screens/profile/components.
