### PR TITLE
add email verification using OTP during signup #66

### DIFF
--- a/apps/users/email_sender.py
+++ b/apps/users/email_sender.py
@@ -10,3 +10,12 @@ def send_forgot_password_email(otp, email, username):
     msg = EmailMultiAlternatives(subject, text_content, os.environ.get('EMAIL_HOST_USER'), [email])
     msg.attach_alternative(html_content, "text/html")
     msg.send()
+
+def send_signup_otp_email(otp, email):
+    subject = 'OTP for Email verification'
+    text_content = f'Your OTP to verify email is {otp}. Expired in 5 minutes.'
+    html_content = f'<p>Your OTP to verify email is <strong>{otp}</strong>. Expired in 5 minutes.</p>'
+
+    msg = EmailMultiAlternatives(subject, text_content, os.environ.get('EMAIL_HOST_USER'), [email])
+    msg.attach_alternative(html_content, "text/html")
+    msg.send()

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -36,3 +36,12 @@ class OneTimePasscode(models.Model):
 
     def __str__(self):
         return f"OTP code for {self.user.email} (expires at {self.expired_at})"
+
+class SignupOneTimePasscode(models.Model):
+    email = models.EmailField(unique=True)
+    code = models.IntegerField()
+    expired_at = models.DateTimeField(default=get_expiry_time)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"OTP code for {self.email} (expires at {self.expired_at})"

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -16,5 +16,6 @@ urlpatterns = [
     path('forgot_change_password/', views.forgot_change_password, name='forgot_change_password'),
     path('user_password_change/', views.user_password_change, name='user_password_change'),
     path('get_user/', views.get_user, name='get_user'),
+    path('signup_email_otp/', views.signup_email_otp, name='signup_email_otp'),
 ]
 

--- a/apps/users/utils.py
+++ b/apps/users/utils.py
@@ -1,5 +1,6 @@
 import secrets
 from .models import OneTimePasscode
+from .models import SignupOneTimePasscode
 from django.contrib.auth import get_user_model
 
 User = get_user_model()
@@ -13,6 +14,20 @@ def create_otp_for_user(user):
 
         otp = OneTimePasscode.objects.create(
             user=user,
+            code=otp_code
+        )
+        return otp
+    except Exception:
+        return None
+
+def create_otp_signup(email):
+    try:
+        otp_code = secrets.randbelow(900000) + 100000
+
+        SignupOneTimePasscode.objects.filter(email=email).delete()
+
+        otp = SignupOneTimePasscode.objects.create(
+            email=email,
             code=otp_code
         )
         return otp

--- a/frontend-dart/lib/core/consolidated_core.dart
+++ b/frontend-dart/lib/core/consolidated_core.dart
@@ -101,6 +101,12 @@ class AppValidators {
       return null;
     };
   }
+
+  static String? otp(String? value) {
+    if (value?.isEmpty ?? true) return 'Please enter OTP';
+    if (!RegExp(r'^\d{6}$').hasMatch(value!)) return 'OTP must be exactly 6 digits';
+    return null;
+  }
 }
 
 class ValidationUtils {
@@ -110,6 +116,7 @@ class ValidationUtils {
   static String? username(String? value) => AppValidators.username(value);
   static String? phoneNumber(String? value, {bool required = false}) => AppValidators.phoneNumber(value, required: required);
   static String? lengthRange(String? value, int min, int max, [String? fieldName]) => AppValidators.lengthRange(value, min, max, fieldName);
+  static String? otp(String? value) => AppValidators.otp(value);
 }
 
 class Validators {

--- a/frontend-dart/lib/providers/auth_provider.dart
+++ b/frontend-dart/lib/providers/auth_provider.dart
@@ -76,9 +76,10 @@ class AuthProvider with ChangeNotifier {
     });
   }
 
-  Future<bool> signup(String username, String email, String password) async {
+  Future<bool> signup(String username, String email, String password, String otpStr) async {
+    int otp = int.parse(otpStr);
     return await _execute(() async {
-      final authResult = await _api.signup(username, email, password);
+      final authResult = await _api.signup(username, email, password, otp);
       _setUserData(authResult.token, authResult.user.id, authResult.user.username);
     });
   }
@@ -149,6 +150,26 @@ class AuthProvider with ChangeNotifier {
     final responseData = json.decode(response.body);
     if (response.statusCode != 200) {
       throw responseData;
+    }
+  }
+
+  Future<bool> signupEmailOtp(String? email) async {
+    try{
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      await _api.signupEmailOtp(email);
+      
+      _isLoading = false;
+      notifyListeners();
+      return true;
+
+    } catch (e) {
+        _errorMessage = e.toString();
+        _isLoading = false;
+        notifyListeners();
+        return false;
     }
   }
 


### PR DESCRIPTION
Backend:
Modify  /users/models.py - add SigupOneTimePasscode.
Modify /users/urls.py - add path - signup_email_otp.
Modify /users/utils.py - add create_otp_signup(email).
Modify /users/email_sender.py - add send_signup_otp_email(otp, email).
Modify /users/views.py - add signup_email_otp(request), modify signup() to include otp checking.

Frontend:
Modify /core/consolidated_core.dart - add validator for otp.
Modify /providers/auth_provider.dart - add signupEmailOtp(), modify signup() with otp.
Modify services/api_service.dart - add signupEmailOtp(), modify signup() with otp.
                             modify _extractErrorMessage() to shows error message of django UserSerializer (see comments in code).
Modify /screens/auth/auth_screen.dart - add otp during signup. I believe Jeffrey is currently still modifying this, i commented some parts add modify some to make it work.
