### PR TITLE
add swagger, fix previous profile issues, hash otp

### DIFF
--- a/apps/profile/admin.py
+++ b/apps/profile/admin.py
@@ -2,12 +2,7 @@
 
 from django.contrib import admin
 
-from .models import ProfilePublic
-from .models import ProfilePrivate
-from .models import ProfileFriend
-from .models import ProfileMusic
+from .models import Profile
 
-admin.site.register(ProfilePublic)
-admin.site.register(ProfilePrivate)
-admin.site.register(ProfileFriend)
-admin.site.register(ProfileMusic)
+admin.site.register(Profile)
+

--- a/apps/profile/models.py
+++ b/apps/profile/models.py
@@ -3,8 +3,8 @@ from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 
 
-class ProfilePublic(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile_public')
+class Profile(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile')
 
     gender = models.CharField(
         max_length=6,
@@ -33,23 +33,6 @@ class ProfilePublic(models.Model):
         blank=True,
         default=''
         )
-
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    class Meta:
-        verbose_name = "User Public Info"
-        verbose_name_plural = "User Public Infos"
-        
-    def __str__(self):
-        return (
-            f"user id: {self.user.id}, gender: {self.gender}, avatar: {self.avatar},"
-            f"location: {self.location}, bio: {self.bio}"
-            )
-
-
-class ProfilePrivate(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile_private')
 
     first_name = models.CharField(
         max_length=50,
@@ -93,23 +76,6 @@ class ProfilePrivate(models.Model):
         default=''
         )
 
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    class Meta:
-        verbose_name = "User Private Info"
-        verbose_name_plural = "User Private Infos"
-        
-    def __str__(self):
-        return (
-            f"user id: {self.user.id}, first_name: {self.first_name}, last_name: {self.last_name},"
-            f"phone: {self.phone}, street: {self.street}, country: {self.country}, postal_code: {self.postal_code}"
-            )
-
-
-class ProfileFriend(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile_friend')
-
     dob = models.DateField(
         null=True, 
         blank=True
@@ -117,6 +83,7 @@ class ProfileFriend(models.Model):
     
     hobbies = ArrayField(
         models.CharField(max_length=50),
+        null=True,
         blank=True,
         default=list
     )
@@ -128,24 +95,9 @@ class ProfileFriend(models.Model):
         default=''
     )
 
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    class Meta:
-        verbose_name = "User Friend Info"
-        verbose_name_plural = "User Friend Infos"
-        
-    def __str__(self):
-        return (
-            f"user id: {self.user.id}, dob: {self.dob}, hobbies: {self.hobbies}, friend_info: {self.friend_info}"
-        )
-
-
-class ProfileMusic(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile_music')
-    
     music_preferences = ArrayField(
         models.CharField(max_length=50),
+        null=True,
         blank=True,
         default=list
     )
@@ -154,10 +106,15 @@ class ProfileMusic(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
-        verbose_name = "User Music Preference"
-        verbose_name_plural = "User Music Preferences"
+        verbose_name = "User Profile"
+        verbose_name_plural = "User Profiles"
         
     def __str__(self):
         return (
-            f"user id: {self.user.id}, music_preferences: {self.music_preferences}"
+            f"user id: {self.user.id}, gender: {self.gender}, avatar: {self.avatar},"
+            f"location: {self.location}, bio: {self.bio},"
+            f"first_name: {self.first_name}, last_name: {self.last_name},"
+            f"phone: {self.phone}, street: {self.street}, country: {self.country}, postal_code: {self.postal_code},"    
+            f"dob: {self.dob}, hobbies: {self.hobbies}, friend_info: {self.friend_info},"
+            f"music_preferences: {self.music_preferences}"
         )

--- a/apps/profile/serializers.py
+++ b/apps/profile/serializers.py
@@ -1,0 +1,81 @@
+from rest_framework import serializers
+from django.core.exceptions import ValidationError
+from .models import Profile
+from datetime import datetime
+
+
+class ProfileSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Profile
+        fields = [
+            'id',
+            'user',
+            'avatar',
+            'gender',
+            'location',
+            'bio',
+            'first_name',
+            'last_name',
+            'phone',
+            'street',
+            'country',
+            'postal_code',
+            'dob',
+            'hobbies',
+            'friend_info',
+            'music_preferences'
+        ]
+        read_only_fields = ['id']
+
+
+    def validate_phone(self, value):
+        if value and not value.isdigit():
+            raise serializers.ValidationError("Phone number must contain only digits.")
+        return value
+
+    def validate_country(self, value):
+        COUNTRIES = ['Singapore', 'Malaysia', 'Indonesia', 'Thailand', 'United States', 'Canada', 'United Kingdom', 'Australia']
+        if value:
+            if value not in COUNTRIES:
+                raise serializers.ValidationError("Country must be 'Singapore', 'Malaysia', 'Indonesia', 'Thailand', 'United States', 'Canada', 'United Kingdom', 'Australia'.")
+        return value
+
+    def validate_postal_code(self, value):
+        if value and not value.isdigit():
+            raise serializers.ValidationError("Postal code must contain only digits.")
+        return value
+
+    def validate_dob(self, value):
+        if value:
+            if value >= datetime.today().date():
+                raise serializers.ValidationError("Dob must be in the past.")
+        return value
+
+    def validate_hobbies(self, value):
+        HOBBIES = ['Sport', 'Movie', 'Music', 'Travel']
+        if value:
+            if not isinstance(value, list):
+                raise serializers.ValidationError("Hobbies must be a list.")
+            for hobby in value:
+                if not isinstance(hobby, str):
+                    raise serializers.ValidationError("Each hobby must be a string.")
+                if hobby not in HOBBIES:
+                    raise serializers.ValidationError(f"{hobby} is not in hobbies list.")
+                if value.count(hobby) > 1:
+                    raise serializers.ValidationError("Each hobby must be unique.")
+        return value
+
+    def validate_music_preferences(self, value):
+        MUSIC_PREFERENCES = ['Classical', 'Jazz', 'Pop', 'Rock', 'Rap', 'R&B', 'Techno']
+        if value:
+            if not isinstance(value, list):
+                raise serializers.ValidationError("Music preferences must be a list.")
+            for pref in value:
+                if not isinstance(pref, str):
+                    raise serializers.ValidationError("Each music preference must be a string.")
+                if pref not in MUSIC_PREFERENCES:
+                    raise serializers.ValidationError(f"{pref} is not in music preferences list.")
+                if value.count(pref) > 1:
+                    raise serializers.ValidationError("Each music preference must be unique.")
+        return value

--- a/apps/profile/urls.py
+++ b/apps/profile/urls.py
@@ -3,13 +3,6 @@ from . import views
 from django.conf import settings
 
 urlpatterns = [
-    path('public/', views.public_info, name='public_info'),
-    path('friend/', views.friend_info, name='friend_info'),
-    path('private/', views.private_info, name='private_info'),
-    path('music/', views.music_preferences, name='music_preferences'),
-    path('public/update/', views.update_public_info, name='update_public_info'),
-    path('friend/update/', views.update_friend_info, name='update_friend_info'),
-    path('private/update/', views.update_private_info, name='update_private_info'),
-    path('music/update/', views.update_music_preferences, name='update_music_pref'),
-
+    path('profile/update/', views.update_profile, name='update_profile'),
+    path('profile/', views.get_profile, name='get_profile'),
 ]

--- a/apps/profile/views.py
+++ b/apps/profile/views.py
@@ -6,273 +6,187 @@ from django.contrib.auth import get_user_model
 import requests
 from rest_framework.response import Response
 from rest_framework.authtoken.models import Token
-from .models import ProfilePublic
-from .models import ProfilePrivate
-from .models import ProfileFriend
-from .models import ProfileMusic
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from django.conf import settings
 import base64
 import uuid
 from urllib.parse import urljoin
+from .models import Profile
+from rest_framework import serializers
+from .serializers import ProfileSerializer
+from django.core.exceptions import ValidationError
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+from PIL import Image
+import io
 
+
+MAX_FILE_SIZE_MB = 1
+MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024
 
 User = get_user_model()
 
+    
 
+@swagger_auto_schema(
+    method='post',
+    operation_summary="Update user profile",
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'avatar_base64': openapi.Schema(type=openapi.TYPE_STRING, description="Base64 encoded avatar image"),
+            'mime_type': openapi.Schema(type=openapi.TYPE_STRING, description="MIME type of the image ('image/jpeg' or 'image/png')"),
+            'gender': openapi.Schema(type=openapi.TYPE_STRING, description="Gender (male or female)"),
+            'location': openapi.Schema(type=openapi.TYPE_STRING),
+            'bio': openapi.Schema(type=openapi.TYPE_STRING),
+            'first_name': openapi.Schema(type=openapi.TYPE_STRING),
+            'last_name': openapi.Schema(type=openapi.TYPE_STRING),
+            'phone': openapi.Schema(type=openapi.TYPE_STRING),
+            'street': openapi.Schema(type=openapi.TYPE_STRING),
+            'country': openapi.Schema(type=openapi.TYPE_STRING),
+            'postal_code': openapi.Schema(type=openapi.TYPE_STRING),
+            'dob': openapi.Schema(type=openapi.TYPE_STRING, format='date', description='Date of birth (YYYY-MM-DD)'),
+            'hobbies': openapi.Schema(type=openapi.TYPE_ARRAY, items=openapi.Items(type=openapi.TYPE_STRING)),
+            'friend_info': openapi.Schema(type=openapi.TYPE_STRING),
+            'music_preferences': openapi.Schema(type=openapi.TYPE_ARRAY, items=openapi.Items(type=openapi.TYPE_STRING)),
+        }
+    ),
+    responses={
+        200: openapi.Response(
+            description="Profile updated successfully",
+            schema=ProfileSerializer()
+            ),
+        401: openapi.Response(
+            description="Unauthorized",
+            schema=openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={'detail': openapi.Schema(type=openapi.TYPE_STRING)},
+                example={'detail': 'Authentication credentials were not provided'}
+            )
+        ),
+        400: openapi.Response(
+            description="Update user profile failed due to error",
+            schema=openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "error": openapi.Schema(type=openapi.TYPE_STRING),
+                },
+                additional_properties=openapi.Schema(
+                    type=openapi.TYPE_ARRAY,
+                    items=openapi.Schema(type=openapi.TYPE_STRING)
+                ),
+                example={
+                    "gender": ["\" malee \" is not a valid choice"],
+                    "phone": ["Phone number must contain only digits"],
+                    "postal_code": ["Postal code must contain only digits"],
+                    "country": ["Country is not in countries list"],
+                    "dob": ["Dob must be in the past"],
+                    "hobbies": ["xxxx is not in hobbies list"],
+                    "hobbies": ["Each hobby must be unique"],
+                    "music_preferences": ["xxxx is not in music preferences list"],
+                    "music_preferences": ["Each music preference must be unique"],
+                    "error": "avatar_base64 is not valid image | mime_type not image/png or image/jpeg"
+                }
+            ),
+        )
+    }
+)
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
-def update_public_info(request):
+def update_profile(request):
     user = request.user
-    avatar_base64 = request.data.get('avatarBase64')
-    mime_type = request.data.get('mimeType')
-    gender = request.data.get('gender')
-    location = request.data.get('location')
-    bio = request.data.get('bio')
-    
+    avatar_base64 = request.data.get('avatar_base64')
+    mime_type = request.data.get('mime_type')
+
+    avatar = ''
+    data = request.data.copy()
+    data['user'] = user.id
+
     try:
-        profile_public = ProfilePublic.objects.filter(user=user).first()
-        if not profile_public:
-            profile_public = ProfilePublic.objects.create(
-                user = user,
-            )
         if mime_type and avatar_base64:
+            if mime_type not in ['image/png', 'image/jpeg']:
+                return JsonResponse({'error': 'mime_type not image/png or image/jpeg'}, status=status.HTTP_400_BAD_REQUEST)
+            if not is_valid_image_base64(avatar_base64, mime_type):
+                return JsonResponse({'error': 'avatar_base64 is not valid image'}, status=status.HTTP_400_BAD_REQUEST)
             ext = '.' + mime_type.split('/')[1]
             filename = uuid.uuid4().hex + ext
             file_data = base64.b64decode(avatar_base64)
+            if len(file_data) > MAX_FILE_SIZE_BYTES:
+                return JsonResponse({'error': f'Avatar file size exceeds {MAX_FILE_SIZE_MB}MB limit'}, status=status.HTTP_400_BAD_REQUEST)
             save_dir = os.path.join(settings.MEDIA_ROOT)
             file_path = os.path.join(save_dir, filename)
             with open(file_path, 'wb') as f:
                 f.write(file_data)
             media_url = urljoin(settings.MEDIA_URL, filename)
             if file_path:
-                profile_public.avatar = media_url
-
-        if gender:
-            profile_public.gender = gender
-        
-        if location:
-            profile_public.location = location
-        
-        if bio:
-            profile_public.bio = bio
-        
-        profile_public.save()
-
-        data = {
-            'avatar': profile_public.avatar,
-            'gender': profile_public.gender,
-            'location': profile_public.location,
-            'bio': profile_public.bio,
-        }
-        return JsonResponse(data, status=status.HTTP_200_OK)
-        
+                avatar = media_url
+            if avatar:
+                data['avatar'] = avatar
     except Exception as e:
-        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        return JsonResponse({'error': '(avatar)'+str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+    profile = Profile.objects.get(user=user)
+    serializer = ProfileSerializer(profile, data=data, partial=True)
+    if serializer.is_valid():
+        profile = serializer.save()
+        return JsonResponse(serializer.data, status=status.HTTP_200_OK)
+    return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+
+@swagger_auto_schema(
+    method='get',
+    operation_summary="Get user profile",
+    responses={
+        200: openapi.Response(
+            description="User profile get successful",
+            schema=ProfileSerializer()
+        ),
+        401: openapi.Response(
+            description="Unauthorized",
+            schema=openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={'detail': openapi.Schema(type=openapi.TYPE_STRING)},
+                example={'detail': 'Authentication credentials were not provided'}
+            )
+        ),
+        400: openapi.Response(
+            description="User profile get failed due to error ",
+            schema=openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={'error': openapi.Schema(type=openapi.TYPE_STRING)},
+            )
+        ),
+    }
+)
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
-def public_info(request):
+def get_profile(request):
     user = request.user
     try:
-        profile_public = ProfilePublic.objects.filter(user=user).first()
-        if not profile_public:
-            profile_public = ProfilePublic.objects.create(
-                user = user,
-            )
-        data = {
-            'avatar': profile_public.avatar,
-            'gender': profile_public.gender,
-            'location': profile_public.location,
-            'bio': profile_public.bio,   
-        }
-        return JsonResponse(data, status=status.HTTP_200_OK)
+        profile = Profile.objects.filter(user=user).first()
+        serializer = ProfileSerializer(profile)
+        return JsonResponse(serializer.data, status=status.HTTP_200_OK)
     except Exception as e:
         return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
 
-@api_view(['POST'])
-@authentication_classes([TokenAuthentication])
-@permission_classes([IsAuthenticated])
-def update_private_info(request):
-    user = request.user
-    first_name = request.data.get('firstName')
-    last_name = request.data.get('lastName')
-    phone = request.data.get('phone')
-    street = request.data.get('street')
-    country = request.data.get('country')
-    postal_code = request.data.get('postalCode')
-    
+
+def is_valid_image_base64(img_base64, mime_type):
+
+    mime_to_format = {
+        'image/png': 'PNG',
+        'image/jpeg': 'JPEG'
+    }
+
     try:
-        profile_private = ProfilePrivate.objects.filter(user=user).first()
-        if not profile_private:
-            profile_private = ProfilePrivate.objects.create(
-                user = user,
-            )
-    
-        if first_name:
-            profile_private.first_name = first_name
-        
-        if last_name:
-            profile_private.last_name = last_name
-
-        if phone:
-            profile_private.phone = phone
-        
-        if street:
-            profile_private.street = street
-        
-        if country:
-            profile_private.country = country
-        
-        if postal_code:
-            profile_private.postal_code = postal_code
-        
-        profile_private.save()
-
-        data = {
-            'first_name': profile_private.first_name,
-            'last_name': profile_private.last_name,
-            'phone': profile_private.phone,
-            'street': profile_private.street,
-            'country': profile_private.country,
-            'postal_code': profile_private.postal_code
-        }
-        return JsonResponse(data, status=status.HTTP_200_OK)
-        
+        image_data = base64.b64decode(img_base64)
+        image = Image.open(io.BytesIO(image_data))
+        image.load()
+        expected_format = mime_to_format.get(mime_type)
+        return image.format == expected_format
     except Exception as e:
-        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-
-@api_view(['GET'])
-@authentication_classes([TokenAuthentication])
-@permission_classes([IsAuthenticated])
-def private_info(request):
-    user = request.user
-    try:
-        profile_private = ProfilePrivate.objects.filter(user=user).first()
-        if not profile_private:
-            profile_private = ProfilePrivate.objects.create(
-                user = user,
-            )
-        data = {
-            'first_name': profile_private.first_name,
-            'last_name': profile_private.last_name,
-            'phone': profile_private.phone,
-            'street': profile_private.street,
-            'country': profile_private.country,
-            'postal_code': profile_private.postal_code
-        }
-        return JsonResponse(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-
-@api_view(['POST'])
-@authentication_classes([TokenAuthentication])
-@permission_classes([IsAuthenticated])
-def update_friend_info(request):
-    user = request.user
-    dob = request.data.get('dob')
-    hobbies = request.data.get('hobbies', [])
-    friend_info = request.data.get('friendInfo')
-    
-    try:
-        profile_friend = ProfileFriend.objects.filter(user=user).first()
-        if not profile_friend:
-            profile_friend = ProfileFriend.objects.create(
-                user = user,
-            )
-    
-        if dob:
-            profile_friend.dob = dob
-        
-        if hobbies:
-            profile_friend.hobbies = hobbies
-
-        if friend_info:
-            profile_friend.friend_info = friend_info
-        
-        profile_friend.save()
-
-        data = {
-            'dob': profile_friend.dob,
-            'hobbies': profile_friend.hobbies,
-            'friend_info': profile_friend.friend_info
-        }
-        return JsonResponse(data, status=status.HTTP_200_OK)
-        
-    except Exception as e:
-        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-
-@api_view(['GET'])
-@authentication_classes([TokenAuthentication])
-@permission_classes([IsAuthenticated])
-def friend_info(request):
-    user = request.user
-    try:
-        profile_friend = ProfileFriend.objects.filter(user=user).first()
-        if not profile_friend:
-            profile_friend = ProfileFriend.objects.create(
-                user = user,
-            )
-        data = {
-            'dob': profile_friend.dob,
-            'hobbies': profile_friend.hobbies,
-            'friend_info': profile_friend.friend_info
-        }
-        return JsonResponse(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-
-@api_view(['POST'])
-@authentication_classes([TokenAuthentication])
-@permission_classes([IsAuthenticated])
-def update_music_preferences(request):
-    user = request.user
-    music_preferences = request.data.get('musicPreferences', [])
-    
-    try:
-        profile_music = ProfileMusic.objects.filter(user=user).first()
-        if not profile_music:
-            profile_music = ProfileMusic.objects.create(
-                user = user,
-            )
-        
-        if music_preferences:
-            profile_music.music_preferences = music_preferences
-        
-        profile_music.save()
-
-        data = {
-            'music_preferences': profile_music.music_preferences,
-        }
-        return JsonResponse(data, status=status.HTTP_200_OK)
-        
-    except Exception as e:
-        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-
-@api_view(['GET'])
-@authentication_classes([TokenAuthentication])
-@permission_classes([IsAuthenticated])
-def music_preferences(request):
-    user = request.user
-    try:
-        profile_music = ProfileMusic.objects.filter(user=user).first()
-        if not profile_music:
-            profile_music = ProfileMusic.objects.create(
-                user = user,
-            )
-        data = {
-            'music_preferences': profile_music.music_preferences,
-        }
-        return JsonResponse(data, status=status.HTTP_200_OK)
-    except Exception as e:
-        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        return False

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -30,7 +30,7 @@ def get_expiry_time():
 
 class OneTimePasscode(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
-    code = models.IntegerField()
+    code = models.CharField(max_length=200)
     expired_at = models.DateTimeField(default=get_expiry_time)
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -39,7 +39,7 @@ class OneTimePasscode(models.Model):
 
 class SignupOneTimePasscode(models.Model):
     email = models.EmailField(unique=True)
-    code = models.IntegerField()
+    code = models.CharField(max_length=200)
     expired_at = models.DateTimeField(default=get_expiry_time)
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/apps/users/utils.py
+++ b/apps/users/utils.py
@@ -2,6 +2,7 @@ import secrets
 from .models import OneTimePasscode
 from .models import SignupOneTimePasscode
 from django.contrib.auth import get_user_model
+from django.contrib.auth.hashers import make_password
 
 User = get_user_model()
 
@@ -14,11 +15,12 @@ def create_otp_for_user(user):
 
         otp = OneTimePasscode.objects.create(
             user=user,
-            code=otp_code
+            code=make_password(str(otp_code))
         )
-        return otp
-    except Exception:
+        return otp_code
+    except Exception as e:
         return None
+
 
 def create_otp_signup(email):
     try:
@@ -28,8 +30,8 @@ def create_otp_signup(email):
 
         otp = SignupOneTimePasscode.objects.create(
             email=email,
-            code=otp_code
+            code=make_password(str(otp_code))
         )
-        return otp
-    except Exception:
+        return otp_code
+    except Exception as e:
         return None

--- a/core/settings.py
+++ b/core/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'channels',
     'apps.remote_auth',
     'apps.profile',
+    'drf_yasg',
 ]
 
 MIDDLEWARE = [
@@ -193,5 +194,16 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 
 
-MEDIA_URL = '/apps/avatars/'
-MEDIA_ROOT = BASE_DIR / 'apps/avatars'
+MEDIA_URL = '/apps/profile/avatars/'
+MEDIA_ROOT = BASE_DIR / 'apps/profile/avatars'
+
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        'Token': {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'Authorization',
+            'description': 'Format: Token <your-token>'
+        }
+    }
+}

--- a/core/urls.py
+++ b/core/urls.py
@@ -18,6 +18,21 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+from rest_framework import permissions
+
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Music Room API",
+        default_version='v1',
+        description="API documentation",
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -28,6 +43,7 @@ urlpatterns = [
     path('devices/', include('apps.devices.urls')),
     path('auth/', include('apps.remote_auth.urls')),
     path('profile/', include('apps.profile.urls')),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,6 +16,7 @@ export PYTHONPATH=/app
 
 echo "Applying migrations..."
 python manage.py makemigrations
+python manage.py makemigrations profile
 python manage.py migrate
 echo "Loading data..."
 if [ -f "/app/sample.json" ]; then

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -16,3 +16,5 @@ pytest-asyncio
 #uvicorn[standard]
 google-auth
 geopy
+drf_yasg
+pillow


### PR DESCRIPTION
Fix issues 
#92 Swagger to handle API documentation -> implemented but not all API endpoints annotated yet, a very tedious process of checking each API end points,  and annotate the input parameters and type of output responses.  
Check and test the APIs here -> http://localhost:8000/swagger/  

Anna, please help to annotate the API endpoints, only after the Music Playlist Editor and Music Track Vote features are completed. I will try annotate your APIs as well, after doing https for the back-end.
Jeffrey, some APIs for Profile are changed, please check the Swagger when encountered API errors.

#77 Hash all otp into database
#74 Provide CURL requests for all new API Endpoints  -> http://localhost:8000/swagger/   , click try it, it will generate the CURL if needed.
#73 Single serializer that handles all fields of the Profile model
#71 Create a unified Profile model
#69 Avatars folder inside profile app
