### PR TITLE
Add swagger+pytest to remote_auth, fix when social signup, create user profile as well

### DIFF
--- a/apps/remote_auth/docs.py
+++ b/apps/remote_auth/docs.py
@@ -1,0 +1,178 @@
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample
+from .docs_serializers import *
+
+
+facebook_login_schema = extend_schema(
+    methods=["POST"],
+    summary="Login or signup via Facebook access token",
+    request=FacebookLoginRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            description="Login successful, returns token and user info",
+            response=FacebookLoginSuccessSerializer
+        ),
+        400: OpenApiResponse(
+            description="Facebook login failed",
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Missing Access Token",
+                    value={"error": "Access token not provided"},
+                ),
+                OpenApiExample(
+                    name="Invalid FB Token",
+                    value={"error": "Invalid Facebook access token"},
+                ),
+                OpenApiExample(
+                    name="Invalid Credentials",
+                    value={"error": "Invalid login credentials"},
+                ),
+                OpenApiExample(
+                    name="Account Already Exists",
+                    value={"error": "Already has a account with same email."},
+                ),
+            ]
+        )
+    }
+)
+
+
+google_login_schema = extend_schema(
+    methods=["POST"],
+    summary="Login or signup via Google",
+    request=GoogleLoginRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            description="Google login successful",
+            response=GoogleLoginSuccessSerializer
+        ),
+        400: OpenApiResponse(
+            description="Google login failed",
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Invalid idToken",
+                    value={"error": "Invalid idToken"},
+                ),
+                OpenApiExample(
+                    name="Missing Social Username",
+                    value={"error": "Invalid social username"},
+                ),
+                OpenApiExample(
+                    name="Missing Social Email",
+                    value={"error": "Invalid social email"},
+                ),
+                OpenApiExample(
+                    name="Missing Social ID",
+                    value={"error": "Invalid social id"},
+                ),
+                OpenApiExample(
+                    name="Account Exists",
+                    value={"error": "Already has a account with same email."},
+                ),
+            ]
+        )
+    }
+)
+
+
+facebook_link_schema = extend_schema(
+    methods=["POST"],
+    summary="Link Facebook account to existing user",
+    request=FacebookLinkRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            description="Facebook account linked successfully",
+            response=FacebookLinkSuccessSerializer
+        ),
+        400: OpenApiResponse(
+            description="Failed to link Facebook account",
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Missing Token",
+                    value={"error": "Access token not provided"},
+                ),
+                OpenApiExample(
+                    name="Invalid FB Token",
+                    value={"error": "Invalid Facebook access token"},
+                ),
+                OpenApiExample(
+                    name="No FB Email",
+                    value={"error": "Invalid login credentials"},
+                ),
+                OpenApiExample(
+                    name="Already Linked",
+                    value={"error": "Social network already linked"},
+                ),
+                OpenApiExample(
+                    name="Email Conflict",
+                    value={"error": "Email use by other user"},
+                ),
+                OpenApiExample(
+                    name="Already In Use",
+                    value={"error": "Email or Social network already in use"},
+                ),
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Missing Auth",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+google_link_schema = extend_schema(
+    methods=["POST"],
+    summary="Link Google account to existing user",
+    request=GoogleLinkRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            description="Google account linked successfully",
+            response=GoogleLinkSuccessSerializer
+        ),
+        400: OpenApiResponse(
+            description="Failed to link Google account",
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Invalid Social Email",
+                    value={"error": "Invalid social email"},
+                ),
+                OpenApiExample(
+                    name="Token Invalid",
+                    value={"error": "Invalid idToken"},
+                ),
+                OpenApiExample(
+                    name="Already Linked",
+                    value={"error": "Social network already linked"},
+                ),
+                OpenApiExample(
+                    name="Email In Use",
+                    value={"error": "Email use by other user"},
+                ),
+                OpenApiExample(
+                    name="Already In Use",
+                    value={"error": "Email or Social network already in use"},
+                ),
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)

--- a/apps/remote_auth/docs_serializers.py
+++ b/apps/remote_auth/docs_serializers.py
@@ -1,0 +1,52 @@
+from rest_framework import serializers
+
+class ErrorSerializer(serializers.Serializer):
+    error = serializers.CharField()
+
+
+#facebook_login
+class FacebookLoginRequestSerializer(serializers.Serializer):
+    fbAccessToken = serializers.CharField(help_text="Facebook access token")
+
+class FacebookLoginUserSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    username = serializers.CharField()
+
+class FacebookLoginSuccessSerializer(serializers.Serializer):
+    token = serializers.CharField()
+    user = FacebookLoginUserSerializer()
+
+
+#google_login
+class GoogleLoginRequestSerializer(serializers.Serializer):
+    idToken = serializers.CharField(required=False)
+    socialId = serializers.CharField(required=False)
+    socialEmail = serializers.EmailField(required=False)
+    socialName = serializers.CharField(required=False)
+
+class GoogleLoginUserSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    username = serializers.CharField()
+
+class GoogleLoginSuccessSerializer(serializers.Serializer):
+    token = serializers.CharField()
+    user = GoogleLoginUserSerializer()
+
+
+#facebook_link
+class FacebookLinkRequestSerializer(serializers.Serializer):
+    fbAccessToken = serializers.CharField()
+
+class FacebookLinkSuccessSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+
+
+#google_link
+class GoogleLinkRequestSerializer(serializers.Serializer):
+    idToken = serializers.CharField(required=False)
+    socialId = serializers.CharField(required=False)
+    socialEmail = serializers.EmailField(required=False)
+    socialName = serializers.CharField(required=False)
+
+class GoogleLinkSuccessSerializer(serializers.Serializer):
+    id = serializers.IntegerField()

--- a/apps/remote_auth/tests/conftest.py
+++ b/apps/remote_auth/tests/conftest.py
@@ -1,0 +1,7 @@
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self._json = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self._json

--- a/apps/remote_auth/tests/test_facebook_link.py
+++ b/apps/remote_auth/tests/test_facebook_link.py
@@ -1,0 +1,169 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from unittest.mock import patch
+from conftest import MockResponse
+from apps.users.tests.conftest import authenticated_user
+from django.contrib.auth.models import User
+from apps.remote_auth.models import SocialNetwork
+
+
+@pytest.mark.django_db
+@patch('requests.get')
+def test_facebook_link_invalid_token(mock_get, authenticated_user):
+    """
+        # Mock request with invalid fbAccessToken
+        # Ensure get response error {"error": "Invalid Facebook access token"}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    
+    mock_get.return_value = MockResponse({"data": {"is_valid": False}}, 200)
+
+    url = reverse("auth:facebook_link")
+
+    payload = {
+        "fbAccessToken": "invalid_token"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Invalid Facebook access token"}
+
+
+@pytest.mark.django_db
+@patch('requests.get')
+def test_facebook_link_empty_token(mock_get, authenticated_user):
+    """
+        # Empty payload
+        # Ensure get response error {'error': 'Access token not provided'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse("auth:facebook_link")
+
+    payload = {}
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Access token not provided'}
+
+
+@pytest.mark.django_db
+@patch('requests.get')
+def test_facebook_link_missing_fb_email(mock_get, authenticated_user):
+    """
+        # Mock responses from fb with missing email return
+        # Ensure get response error {"error": "Invalid login credentials"}
+    """
+    mock_get.side_effect = [
+        MockResponse({"data": {"is_valid": True, "user_id": "123"}}, 200),
+        MockResponse({"id": "123", "name": "my_name"}, 200)
+    ]
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse("auth:facebook_link")
+
+    payload = {
+        "fbAccessToken": "1111111111"
+    }
+
+    response = client.post(url, payload, format='json')
+    assert response.status_code == 400
+    assert response.json() == {"error": "Invalid login credentials"}
+
+
+@pytest.mark.django_db
+@patch('requests.get')
+def test_facebook_link_email_used_by_another_user(mock_get, authenticated_user):
+    """
+        # Social email already in use
+        # Ensure get response error {"error": "Email use by other user"}
+    """
+    mock_get.side_effect = [
+        MockResponse({"data": {"is_valid": True,"user_id": "123"}}, 200),
+        MockResponse({"id": "123","email": "user248@example.com","name": "my_name"}, 200)
+    ]
+
+    another_user = User.objects.create_user(
+        username="my_name",
+        email="user248@example.com",
+        password="somePassword248"
+    )
+
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse('auth:facebook_link')
+
+    payload = {
+        "fbAccessToken": "1111111111"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Email use by other user"}
+
+
+@pytest.mark.django_db
+@patch('requests.get')
+def test_facebook_link_already_linked(mock_get, authenticated_user):
+    """
+        # Social network already linked
+        # Ensure get response error {"error": "Social network already linked"}
+    """
+    mock_get.side_effect = [
+        MockResponse({"data": {"is_valid": True,"user_id": "123"}}, 200),
+        MockResponse({"id": "123","email": "user248@example.com","name": "my_name"}, 200)
+    ]
+
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse('auth:facebook_link')
+
+    SocialNetwork.objects.create(
+        user=user,
+        type="facebook",
+        email="user248@example.com",
+        name="my_name",
+        social_id="111111"
+    )
+
+    payload = {
+        "fbAccessToken": "1111111111"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Social network already linked"}
+
+
+@pytest.mark.django_db
+@patch('requests.get')
+def test_facebook_link_success(mock_get, authenticated_user):
+    """
+        # Mock valid responses from fb
+        # Ensure get response {'id': 5}
+    """
+    mock_get.side_effect = [
+        MockResponse({"data": {"is_valid": True,"user_id": "1111111"}}, 200),
+        MockResponse({"id": "111111","email": "user123@example.com","name": "my_name"}, 200)
+    ]
+
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse("auth:facebook_link")
+
+    payload = {
+        "fbAccessToken": "1111111111"
+    }
+
+    response = client.post(url, payload, format='json')
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id}
+    assert SocialNetwork.objects.filter(user=user, social_id="111111").exists()

--- a/apps/remote_auth/tests/test_facebook_login.py
+++ b/apps/remote_auth/tests/test_facebook_login.py
@@ -1,0 +1,90 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from unittest.mock import patch
+from conftest import MockResponse
+
+
+@patch('requests.get')
+def test_facebook_login_invalid_token(mock_get):
+    """
+        # Mock request with invalid fbAccessToken
+        # Ensure get response error {"error": "Invalid Facebook access token"}
+    """
+    mock_get.return_value = MockResponse({"data": {"is_valid": False}}, 200)
+
+    client = APIClient()
+    url = reverse("auth:facebook_login")
+
+    payload = {
+        "fbAccessToken": "invalid_token"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Invalid Facebook access token"}
+
+
+@patch('requests.get')
+def test_facebook_login_empty_token(mock_get):
+    """
+        # Empty payload
+        # Ensure get response error {'error': 'Access token not provided'}
+    """
+    client = APIClient()
+    url = reverse("auth:facebook_login")
+
+    payload = {}
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Access token not provided'}
+
+
+@patch('requests.get')
+def test_facebook_login_missing_fb_email(mock_get):
+    """
+        # Mock responses from fb with missing email return
+        # Ensure get response error {"error": "Invalid login credentials"}
+    """
+    mock_get.side_effect = [
+        MockResponse({"data": {"is_valid": True, "user_id": "123"}}, 200),
+        MockResponse({"id": "123", "name": "my_name"}, 200)
+    ]
+
+    client = APIClient()
+    url = reverse('auth:facebook_login')
+
+    payload = {
+        "fbAccessToken": "1111111111"
+    }
+
+    response = client.post(url, payload, format='json')
+    assert response.status_code == 400
+    assert response.json() == {"error": "Invalid login credentials"}
+
+
+@pytest.mark.django_db
+@patch('requests.get')
+def test_facebook_login_success(mock_get):
+    """
+        # Mock valid responses from fb
+        # Ensure get response {'token': '*******', 'user': {'email': 'user123@example.com', 'id': 2, 'username': 'my_name'}}
+    """
+    mock_get.side_effect = [
+        MockResponse({"data": {"is_valid": True,"user_id": "123"}}, 200),
+        MockResponse({"id": "123","email": "user123@example.com","name": "my_name"}, 200)
+    ]
+
+    client = APIClient()
+    url = reverse('auth:facebook_login')
+
+    payload = {
+        "fbAccessToken": "1111111111"
+    }
+
+    response = client.post(url, payload, format='json')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['user']['username'] == "my_name"
+    assert data['user']['email'] == "user123@example.com"

--- a/apps/remote_auth/tests/test_google_link.py
+++ b/apps/remote_auth/tests/test_google_link.py
@@ -1,0 +1,189 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from unittest.mock import patch
+from conftest import MockResponse
+from apps.users.tests.conftest import authenticated_user
+from django.contrib.auth.models import User
+from apps.remote_auth.models import SocialNetwork
+
+
+@patch('google.oauth2.id_token.verify_oauth2_token')
+def test_google_link_invalid_token(mock_verify, authenticated_user):
+    """
+        # Mock id_token.verify_oauth2_token with invalid idToken
+        # Ensure get response error {"error": "Invalid idToken"}
+    """
+    mock_verify.side_effect = ValueError("Invalid token")
+
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse('auth:google_link')
+
+    payload = {
+        "idToken": "invalid_token"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Invalid idToken"}
+
+
+def test_google_link_empty(authenticated_user):
+    """
+        # Empty payload
+        # Ensure get response error {'error': 'Invalid social username'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse('auth:google_link')
+
+    payload = {}
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Invalid social username'}
+
+
+def test_google_link_missing_social_id(authenticated_user):
+    """
+        # No id_token, missing socialId in payload
+        # Ensure get response error {'error': 'Invalid social id'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse('auth:google_link')
+
+    payload = {
+        "socialName": "my_name",
+        "socialEmail": "user123@example.com"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Invalid social id'}
+
+
+def test_google_link_missing_social_name(authenticated_user):
+    """
+        # No id_token, missing socialName in payload
+        # Ensure get response error {'error': 'Invalid social username'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse('auth:google_link')
+
+    payload = {
+        "socialId": "111111",
+        "socialEmail": "user123@example.com"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Invalid social username'}
+
+
+def test_google_link_missing_social_email(authenticated_user):
+    """
+        # No id_token, missing socialEmail in payload
+        # Ensure get response error {'error': 'Invalid social email'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse('auth:google_link')
+
+    payload = {
+        "socialId": "111111",
+        "socialName": "my_name"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Invalid social email'}
+
+
+@pytest.mark.django_db
+def test_google_link_email_used_by_another_user(authenticated_user):
+    """
+        # Social email already in use
+        # Ensure get response error {"error": "Email use by other user"}
+    """
+    another_user = User.objects.create_user(
+        username="user248",
+        email="user248@example.com",
+        password="somePassword248"
+    )
+
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse('auth:google_link')
+
+    payload = {
+        "socialId": "111111",
+        "socialName": "my_name",
+        "socialEmail": "user248@example.com"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Email use by other user"}
+
+
+@pytest.mark.django_db
+def test_google_link_already_linked(authenticated_user):
+    """
+        # Social network already linked
+        # Ensure get response error {"error": "Social network already linked"}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse('auth:google_link')
+
+    SocialNetwork.objects.create(
+        user=user,
+        type="google",
+        email="user123@example.com",
+        name="my_name",
+        social_id="111111"
+    )
+
+    payload = {
+        "socialId": "111111",
+        "socialName": "my_name",
+        "socialEmail": "user123@example.com"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Social network already linked"}
+
+
+@pytest.mark.django_db
+def test_google_link_success(authenticated_user):
+    """
+        # Valid payload
+        # Ensure get response {'id': 5}
+    """    
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse('auth:google_link')
+    
+    payload = {
+        "socialId": "111111",
+        "socialName": "my_name",
+        "socialEmail": "user123@example.com"
+    }
+
+    response = client.post(url, payload, format="json")
+
+    assert response.status_code == 200
+    assert response.json() == {"id": user.id}
+    assert SocialNetwork.objects.filter(user=user, social_id="111111").exists()

--- a/apps/remote_auth/tests/test_google_login.py
+++ b/apps/remote_auth/tests/test_google_login.py
@@ -1,0 +1,143 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from unittest.mock import patch
+
+
+@patch('google.oauth2.id_token.verify_oauth2_token')
+def test_google_login_invalid_token(mock_verify):
+    """
+        # Mock id_token.verify_oauth2_token with invalid idToken
+        # Ensure get response error {"error": "Invalid idToken"}
+    """
+    mock_verify.side_effect = ValueError("Invalid token")
+
+    client = APIClient()
+    url = reverse('auth:google_login')
+
+    payload = {
+        "idToken": "invalid_token"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Invalid idToken"}
+
+
+def test_google_login_empty():
+    """
+        # Empty payload
+        # Ensure get response error {'error': 'Invalid social username'}
+    """
+    client = APIClient()
+    url = reverse('auth:google_login')
+
+    payload = {}
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Invalid social username'}
+
+
+def test_google_login_missing_social_id():
+    """
+        # No id_token, missing socialId in payload
+        # Ensure get response error {'error': 'Invalid social id'}
+    """
+    client = APIClient()
+    url = reverse('auth:google_login')
+
+    payload = {
+        "socialName": "my_name",
+        "socialEmail": "user123@example.com"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Invalid social id'}
+
+
+def test_google_login_missing_social_name():
+    """
+        # No id_token, missing socialName in payload
+        # Ensure get response error {'error': 'Invalid social username'}
+    """
+    client = APIClient()
+    url = reverse('auth:google_login')
+
+    payload = {
+        "socialId": "111111",
+        "socialEmail": "user123@example.com"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Invalid social username'}
+
+
+def test_google_login_missing_social_email():
+    """
+        # No id_token, missing socialEmail in payload
+        # Ensure get response error {'error': 'Invalid social email'}
+    """
+    client = APIClient()
+    url = reverse('auth:google_login')
+
+    payload = {
+        "socialId": "111111",
+        "socialName": "my_name"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Invalid social email'}
+
+
+@pytest.mark.django_db
+@patch('google.oauth2.id_token.verify_oauth2_token')
+def test_google_login_id_token_success(mock_verify):
+    """
+        # Mock id_token.verify_oauth2_token with valid idToken
+        # Ensure get response {'token': '******', 'user': {'email': 'user123@example.com', 'id': 7, 'username': 'my_name'}}
+    """
+    mock_verify.return_value = {
+        'email': 'user123@example.com',
+        'name': 'my_name',
+        'sub': '111111'
+    }
+
+    client = APIClient()
+    url = reverse('auth:google_login')
+
+    payload = {
+        "idToken": "valid_token"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data['user']['username'] == "my_name"
+    assert data['user']['email'] == "user123@example.com"
+
+
+@pytest.mark.django_db
+def test_google_login_no_id_token_success():
+    """
+        # No idToken, but with valid payload
+        # Ensure get response {'token': '******', 'user': {'email': 'user123@example.com', 'id': 7, 'username': 'my_name'}}
+    """
+
+    client = APIClient()
+    url = reverse('auth:google_login')
+
+    payload = {
+        "socialId": "111111",
+        "socialName": "my_name",
+        "socialEmail": "user123@example.com"
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data['user']['username'] == "my_name"
+    assert data['user']['email'] == "user123@example.com"

--- a/apps/remote_auth/tests/test_models.py
+++ b/apps/remote_auth/tests/test_models.py
@@ -1,0 +1,29 @@
+import pytest
+from apps.remote_auth.models import SocialNetwork
+from django.contrib.auth.models import User
+
+
+@pytest.mark.django_db
+def test_create_socialnetwork():
+
+    email = "user248@example.com"
+    type = "facebook"
+    social_id = "111111111"
+
+    user = User.objects.create_user(
+        username="my_name",
+        email="user248@example.com",
+        password="somePassword248"
+    )
+
+    social_network = SocialNetwork.objects.create(
+        email = email,
+        type = type,
+        social_id = social_id,
+        user = user
+    )
+
+    assert social_network.email == email
+    assert social_network.type == type
+    assert social_network.social_id == social_id
+    assert social_network.user == user

--- a/apps/remote_auth/tests/test_serializers.py
+++ b/apps/remote_auth/tests/test_serializers.py
@@ -1,0 +1,90 @@
+import pytest
+from apps.remote_auth.serializers import RemoteUserSerializer
+from django.contrib.auth.models import User
+
+
+@pytest.mark.django_db
+def test_remote_user_serializer_space_in_username():
+    """
+        # Spaces in username
+        # Ensure get error - "Username cannot have leading or trailing spaces."
+    """
+    payload = {
+        "username": " user123  ",
+        "email": "user123@example.com"
+    }
+    serializer = RemoteUserSerializer(data=payload)
+    assert not serializer.is_valid()
+    assert "username" in serializer.errors
+    assert serializer.errors["username"][0] == "Username cannot have leading or trailing spaces."
+
+
+@pytest.mark.django_db
+def test_remote_user_serializer_username_in_use():
+    """
+        # Username already in use
+        # Ensure get error - "Username is already taken."
+    """
+    User.objects.create(username="user123", email="user123@example.com")
+    
+    payload = {
+        "username": "user123",
+        "email": "user123@example.com"
+    }
+    serializer = RemoteUserSerializer(data=payload)
+    assert not serializer.is_valid()
+    assert "username" in serializer.errors
+    assert serializer.errors["username"][0] == "Username is already taken."
+
+
+@pytest.mark.django_db
+def test_remote_user_serializer_invalid_email_format():
+    """
+        # Invalid email format
+        # Ensure get error - "Enter a valid email address."
+    """
+    payload = {
+        "username": "user123",
+        "email": "user123##example.com"
+    }
+    serializer = RemoteUserSerializer(data=payload)
+    assert not serializer.is_valid()
+    assert "email" in serializer.errors
+    assert serializer.errors["email"][0] == "Enter a valid email address."
+
+
+@pytest.mark.django_db
+def test_remote_user_serializer_email_in_use():
+    """
+        # Invalid email in use
+        # Ensure get error - "Email is already taken."
+    """
+    User.objects.create(username="user123", email="user123@example.com")
+    
+    payload = {
+        "username": "user248",
+        "email": "user123@example.com"
+    }
+
+    serializer = RemoteUserSerializer(data=payload)
+    assert not serializer.is_valid()
+    assert "email" in serializer.errors
+    assert serializer.errors["email"][0] == "Email is already taken."
+
+
+@pytest.mark.django_db
+def test_remote_user_serializer_success():
+    """
+        # Valid username, email
+        # Ensure user added
+    """
+    payload = {
+        "username": "user123",
+        "email": "user123@example.com"
+    }
+
+    serializer = RemoteUserSerializer(data=payload)
+    assert serializer.is_valid()
+    user = serializer.save()
+    assert user.username == "user123"
+    assert user.email == "user123@example.com"

--- a/apps/remote_auth/urls.py
+++ b/apps/remote_auth/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from . import views
 
+app_name = "auth"
+
 urlpatterns = [
     path('facebook/login/', views.facebook_login, name='facebook_login'),
     path('google/login/', views.google_login, name='google_login'),


### PR DESCRIPTION
Backend
Add swagger API documentation + pytest to following end points.
auth/facebook/login/
auth/facebook/link/
auth/google/login/
auth/google/link/

Fix social_login() in apps/remote_auth/views.py, to create a user profile if signup is successful.

See API documentation here: http://localhost:8000/api/schema/swagger-ui/
Run pytest with command: docker compose exec django pytest

