### PR TITLE
Add swagger+pytest to deezer API end points

### DIFF
--- a/apps/deezer/docs.py
+++ b/apps/deezer/docs.py
@@ -1,0 +1,74 @@
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample, OpenApiParameter
+from .docs_serializers import *
+
+
+get_deezer_track_schema = extend_schema(
+    methods=["GET"],
+    summary="Retrieve a Deezer track by ID",
+    parameters=[
+        {
+            "name": "track_id",
+            "required": True,
+            "in": "path",
+            "description": "ID of the Deezer track",
+            "schema": {"type": "string"},
+        }
+    ],
+    responses={
+        200: OpenApiResponse(
+            description="Track info retrieved successfully",
+            response=DeezerTrackSerializer,
+        ),
+        404: OpenApiResponse(
+            description="Track not found",
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Track Not Found",
+                    value={"error": "Track not found"},
+                )
+            ],
+        ),
+    }
+)
+
+
+search_deezer_tracks_schema = extend_schema(
+    methods=["GET"],
+    summary="Search Deezer tracks by query",
+    parameters=[
+        OpenApiParameter(
+            name="q",
+            required=True,
+            location=OpenApiParameter.QUERY,
+            description="Search query string",
+            type=str,
+        )
+    ],
+    responses={
+        200: OpenApiResponse(
+            description="List of tracks matching the search query",
+            response=DeezerTrackSearchResponseSerializer,
+        ),
+        400: OpenApiResponse(
+            description="Missing query parameter",
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Missing Query",
+                    value={"error": "Query parameter 'q' is required."},
+                )
+            ],
+        ),
+        502: OpenApiResponse(
+            description="Failed to fetch data from Deezer",
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Deezer API Failure",
+                    value={"error": "Failed to fetch data from Deezer."},
+                )
+            ],
+        ),
+    }
+)

--- a/apps/deezer/docs_serializers.py
+++ b/apps/deezer/docs_serializers.py
@@ -1,0 +1,85 @@
+from rest_framework import serializers
+
+class ErrorSerializer(serializers.Serializer):
+    error = serializers.CharField()
+
+
+class DeezerContributorSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    link = serializers.URLField()
+    share = serializers.URLField()
+    picture = serializers.URLField()
+    picture_small = serializers.URLField()
+    picture_medium = serializers.URLField()
+    picture_big = serializers.URLField()
+    picture_xl = serializers.URLField()
+    radio = serializers.BooleanField()
+    tracklist = serializers.URLField()
+    type = serializers.CharField()
+    role = serializers.CharField()
+
+
+class DeezerArtistSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    link = serializers.URLField()
+    share = serializers.URLField()
+    picture = serializers.URLField()
+    picture_small = serializers.URLField()
+    picture_medium = serializers.URLField()
+    picture_big = serializers.URLField()
+    picture_xl = serializers.URLField()
+    radio = serializers.BooleanField()
+    tracklist = serializers.URLField()
+    type = serializers.CharField()
+
+
+class DeezerAlbumSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    title = serializers.CharField()
+    link = serializers.URLField()
+    cover = serializers.URLField()
+    cover_small = serializers.URLField()
+    cover_medium = serializers.URLField()
+    cover_big = serializers.URLField()
+    cover_xl = serializers.URLField()
+    md5_image = serializers.CharField()
+    release_date = serializers.DateField()
+    tracklist = serializers.URLField()
+    type = serializers.CharField()
+
+
+class DeezerTrackSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    readable = serializers.BooleanField()
+    title = serializers.CharField()
+    title_short = serializers.CharField()
+    title_version = serializers.CharField(allow_blank=True)
+    isrc = serializers.CharField()
+    link = serializers.URLField()
+    share = serializers.URLField()
+    duration = serializers.IntegerField()
+    track_position = serializers.IntegerField()
+    disk_number = serializers.IntegerField()
+    rank = serializers.IntegerField()
+    release_date = serializers.DateField()
+    explicit_lyrics = serializers.BooleanField()
+    explicit_content_lyrics = serializers.IntegerField()
+    explicit_content_cover = serializers.IntegerField()
+    preview = serializers.URLField()
+    bpm = serializers.FloatField()
+    gain = serializers.FloatField()
+    available_countries = serializers.ListField(child=serializers.CharField())
+    contributors = DeezerContributorSerializer(many=True)
+    md5_image = serializers.CharField()
+    track_token = serializers.CharField()
+    artist = DeezerArtistSerializer()
+    album = DeezerAlbumSerializer()
+    type = serializers.CharField()
+
+
+class DeezerTrackSearchResponseSerializer(serializers.Serializer):
+    data = DeezerTrackSerializer(many=True)
+    total = serializers.IntegerField()
+    next = serializers.URLField(allow_null=True)

--- a/apps/deezer/tests/test_get_deezer_track.py
+++ b/apps/deezer/tests/test_get_deezer_track.py
@@ -1,0 +1,41 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from unittest.mock import patch
+
+
+@patch('apps.deezer.views.DeezerClient')
+def test_get_deezer_track_not_found(mock_deezer_client):
+    """
+        # Mock track not found
+        # Ensure reponse error {"error": "Track not found"}
+    """
+    client = APIClient()
+    url = reverse("deezer:get_deezer_track", kwargs={'track_id': 999})
+
+    mock_deezer_client.return_value.get_track.return_value = None
+
+    response = client.get(url)
+    assert response.status_code == 404
+    assert response.json() == {"error": "Track not found"}
+
+
+@patch('apps.deezer.views.DeezerClient')
+def test_get_deezer_track_success(mock_deezer_client):
+    """
+        # Mock track return
+        # Ensure reponse track_data
+    """
+    client = APIClient()
+    url = reverse("deezer:get_deezer_track", kwargs={'track_id': 999})
+
+    mock_track_data = {
+        "id": 999,
+        "title": "Test Track",
+        "artist": {"name": "Test Artist"},
+    }
+    mock_deezer_client.return_value.get_track.return_value = mock_track_data
+
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.json() == mock_track_data

--- a/apps/deezer/tests/test_search_deezer_tracks.py
+++ b/apps/deezer/tests/test_search_deezer_tracks.py
@@ -1,0 +1,50 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from unittest.mock import patch
+
+
+def test_search_deezer_tracks_empty_query():
+    """
+        # Empty query string
+        # Ensure reponse error {"error": "Query parameter 'q' is required."}
+    """
+    client = APIClient()
+    url = reverse("deezer:search_deezer_tracks")
+
+    response = client.get(url)
+    assert response.status_code == 400
+    assert response.json() == {"error": "Query parameter 'q' is required."}
+
+
+@patch('apps.deezer.views.DeezerClient')
+def test_search_deezer_tracks_api_failure(mock_deezer_client):
+    """
+        # Mock a fail deezer api call
+        # Ensure reponse error {"error": "Failed to fetch data from Deezer."}
+    """
+    client = APIClient()
+    url = reverse("deezer:search_deezer_tracks")
+
+    mock_deezer_client.return_value.search_tracks.return_value = None
+
+    response = client.get(url, {'q': 'test'})
+    assert response.status_code == 502
+    assert response.json() == {"error": "Failed to fetch data from Deezer."}
+
+
+@patch('apps.deezer.views.DeezerClient')
+def test_search_deezer_tracks_success(mock_deezer_client):
+    """
+        # Mock a deezer valid search response
+        # Ensure reponse {"data": [{"id": 1, "title": "Test Track"}]}
+    """
+    client = APIClient()
+    url = reverse("deezer:search_deezer_tracks")
+
+    mock_results = {"data": [{"id": 1, "title": "Test Track"}]}
+    mock_deezer_client.return_value.search_tracks.return_value = mock_results
+
+    response = client.get(url, {'q': 'test'})
+    assert response.status_code == 200
+    assert response.json() == mock_results

--- a/apps/deezer/urls.py
+++ b/apps/deezer/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from .views import get_deezer_track, search_deezer_tracks
 
+app_name = "deezer"
+
 urlpatterns = [
     path('track/<str:track_id>/', get_deezer_track, name='get_deezer_track'),
     path('search/', search_deezer_tracks, name='search_deezer_tracks'),

--- a/apps/deezer/views.py
+++ b/apps/deezer/views.py
@@ -2,8 +2,10 @@ from django.http import JsonResponse
 from .deezer_client import DeezerClient
 from rest_framework.decorators import api_view
 from rest_framework import status
+from .docs import *
 
 
+@get_deezer_track_schema
 @api_view(['GET'])
 def get_deezer_track(request, track_id):
     client = DeezerClient()
@@ -15,6 +17,7 @@ def get_deezer_track(request, track_id):
         return JsonResponse({'error': 'Track not found'}, status=404)
 
 
+@search_deezer_tracks_schema
 @api_view(['GET'])
 def search_deezer_tracks(request):
     query = request.GET.get('q')
@@ -28,3 +31,4 @@ def search_deezer_tracks(request):
         return JsonResponse({"error": "Failed to fetch data from Deezer."}, status=status.HTTP_502_BAD_GATEWAY)
 
     return JsonResponse(results)
+


### PR DESCRIPTION
Back-end
Added Swagger API documentation + pytest cases to the following end points:
deezer/track/<str:track_id>/
deezer/search/

Swagger API documentation at: http://localhost:8000/api/schema/swagger-ui/
Run pytest: docker compose exec django pytest

Please check the API documentation and testcases, modify if needed.