### PR TITLE
Add swagger+pytest to profile apis

### DIFF
--- a/apps/profile/docs.py
+++ b/apps/profile/docs.py
@@ -1,0 +1,119 @@
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample
+from .docs_serializers import *
+from .serializers import ProfileSerializer, MusicPreferenceSerializer
+
+
+profile_update_schema = extend_schema(
+    methods=["PUT", "PATCH"],
+    summary="Update the authenticated user's profile",
+    request=ProfileSerializer,
+    responses={
+        200: OpenApiResponse(
+            description="Profile updated successfully",
+            response=ProfileSerializer,
+        ),
+        400: OpenApiResponse(
+            description="Validation error",
+            response=ErrorMultiSerializer,
+        ),
+    },
+)
+
+
+profile_detail_schema = extend_schema(
+    methods=["GET"],
+    summary="Retrieve a user profile",
+    parameters=[
+        {
+            "name": "pk",
+            "required": True,
+            "in": "path",
+            "description": "User ID",
+            "schema": {"type": "string"},
+        },
+    ],
+    responses={
+        200: OpenApiResponse(
+            description="Return profile details",
+            response=ProfileSerializer
+        ),
+        401: OpenApiResponse(
+            description="Authentication credentials invalid", 
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided"},
+                ),
+                OpenApiExample(
+                    name="Invalid Token",
+                    value={"detail": "Invalid token."},
+                ),
+            ]
+        ),
+        404: OpenApiResponse(
+            description="Profile not found", 
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Profile Not Found",
+                    value={"detail": "No Profile matches the given query."},
+                )
+            ],
+        ),
+    },
+)
+
+
+delete_avatar_schema = extend_schema(
+    methods=["DELETE"],
+    summary="Delete current user's avatar",
+    request=None,
+    responses={
+        204: OpenApiResponse(
+            description="Avatar deleted successfully",
+        ),
+        400: OpenApiResponse(
+            description="No avatar to delete",
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="No Avatar",
+                    value={"detail": "No avatar to delete."},
+                )
+            ],
+        ),
+        401: OpenApiResponse(
+            description="Authentication credentials invalid", 
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided"},
+                ),
+            ]
+        ),
+    },
+)
+
+
+music_preferences_list_schema = extend_schema(
+    methods=["GET"],
+    summary="List music preferences",
+    responses={
+        200: OpenApiResponse(
+            description="A list of music preferences",
+            response=MusicPreferenceSerializer(many=True)
+        ),
+        401: OpenApiResponse(
+            description="Authentication credentials invalid", 
+            response=ErrorSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided"},
+                ),
+            ]
+        ),
+    },
+)

--- a/apps/profile/docs_serializers.py
+++ b/apps/profile/docs_serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+
+class ErrorSerializer(serializers.Serializer):
+    error = serializers.CharField()
+
+
+class ErrorMultiSerializer(serializers.Serializer):
+    detail = serializers.DictField(
+        child=serializers.ListField(child=serializers.CharField())
+    )
+
+
+class DetailSerializer(serializers.Serializer):
+    detail = serializers.CharField()

--- a/apps/profile/tests/conftest.py
+++ b/apps/profile/tests/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+from apps.profile.models import VisibilityChoices, MusicPreference
+from PIL import Image
+from django.core.files.uploadedfile import SimpleUploadedFile
+import io
+
+
+def user_init_profile(authenticated_user):
+
+    user, _ = authenticated_user
+    
+    mp1 = MusicPreference.objects.create(name="rock")
+    mp2 = MusicPreference.objects.create(name="jazz")
+
+    user.profile.avatar = "user123_xxx.png"
+    user.profile.avatar_visibility = VisibilityChoices.PUBLIC
+    user.profile.name = "user123"
+    user.profile.name_visibility = VisibilityChoices.PUBLIC
+    user.profile.location = "SUTD"
+    user.profile.location_visibility = VisibilityChoices.PUBLIC
+    user.profile.bio = "Hello !"
+    user.profile.bio_visibility = VisibilityChoices.PUBLIC
+    user.profile.phone = "+6591234567"
+    user.profile.phone_visibility = VisibilityChoices.PRIVATE
+    user.profile.friend_info = "Hello Friend !"
+    user.profile.friend_info_visibility = VisibilityChoices.FRIENDS
+    user.profile.music_preferences.add(mp1, mp2)
+    user.profile.music_preferences_visibility = VisibilityChoices.FRIENDS
+    user.profile.save()
+
+    return user
+
+
+def make_image_file(filename="avatar.png", size=(10, 10), color=(255, 0, 0)):
+    img = Image.new("RGB", size, color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return SimpleUploadedFile(filename, buf.read(), content_type="image/png")

--- a/apps/profile/tests/test_delete_avatar.py
+++ b/apps/profile/tests/test_delete_avatar.py
@@ -1,0 +1,45 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.profile.tests.conftest import user_init_profile, make_image_file
+
+
+@pytest.mark.django_db
+def test_delete_avatar_no_avatar(authenticated_user):
+    """
+        # No avatar in user profile
+        # Ensure response error {'detail': 'No avatar to delete.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse("profile:delete-avatar")
+
+    response = client.delete(url)
+    assert response.status_code == 400
+    assert response.json() == {'detail': 'No avatar to delete.'}
+
+
+@pytest.mark.django_db
+def test_delete_avatar(authenticated_user):
+    """
+        # Delete avatar in user profile
+        # Ensure response status code == 204
+    """
+    image = make_image_file()
+
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse("profile:profile-update")
+
+    payload = {
+        "avatar": image
+    }
+    response = client.patch(url, payload, format="multipart")
+    assert response.status_code == 200
+
+    url = reverse("profile:delete-avatar")
+    response = client.delete(url)
+    assert response.status_code == 204

--- a/apps/profile/tests/test_music_preferences_list.py
+++ b/apps/profile/tests/test_music_preferences_list.py
@@ -1,0 +1,33 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.profile.models import MusicPreference
+
+
+@pytest.mark.django_db
+def test_music_preferences_list(authenticated_user):
+    """
+        # Create music prefernces and returns it
+        # Ensure response contains created music preferences
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse("profile:music-preferences-list")
+
+    p1 = MusicPreference.objects.create(name="rock")
+    p2 = MusicPreference.objects.create(name="jazz")
+    p3 = MusicPreference.objects.create(name="pop")
+
+    response = client.get(url)
+    assert response.status_code == 200
+    data = response.json()
+    prefs_ids = [item["id"] for item in data]
+    assert p1.id in prefs_ids
+    assert p2.id in prefs_ids
+    assert p3.id in prefs_ids
+    prefs_names = [item["name"] for item in data]
+    assert p1.name in prefs_names
+    assert p2.name in prefs_names
+    assert p3.name in prefs_names

--- a/apps/profile/tests/test_profile_detail.py
+++ b/apps/profile/tests/test_profile_detail.py
@@ -1,0 +1,48 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.profile.tests.conftest import user_init_profile
+import uuid
+
+
+def test_profile_view_own(authenticated_user):
+    """
+        # Authenticated user with default init profile values
+        # Ensure response matches the default init profile values
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    user = user_init_profile(authenticated_user)
+    url = reverse('profile:profile-detail', kwargs={'pk': user.id})
+
+    response = client.get(url)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["avatar"] == "http://testserver/apps/profile/avatars/user123_xxx.png"
+    assert data["name"] == "user123"
+    assert data["location"] == "SUTD"
+    assert data["bio"] == "Hello !"
+    assert data["phone"] == "+6591234567"
+    assert data["friend_info"] == "Hello Friend !"
+    assert set(data["music_preferences"]) == {"rock", "jazz"}
+
+
+def test_profile_view_not_found(authenticated_user):
+    """
+        # Invalid user uuid
+        # Ensure response error {'detail': 'No Profile matches the given query.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    test_uuid = uuid.uuid4()
+    url = reverse('profile:profile-detail', kwargs={'pk': test_uuid})
+
+    response = client.get(url)
+    assert response.status_code == 404
+    assert response.json() == {'detail': 'No Profile matches the given query.'}

--- a/apps/profile/tests/test_profile_models.py
+++ b/apps/profile/tests/test_profile_models.py
@@ -1,0 +1,19 @@
+import pytest
+from apps.users.tests.conftest import authenticated_user
+from apps.profile.models import VisibilityChoices
+
+
+def test_create_profile(authenticated_user):
+    """
+        # authenticated_user created together with profile
+    """
+    user, _ = authenticated_user
+
+    assert user.profile.user == user
+    assert user.profile.avatar_visibility == VisibilityChoices.PUBLIC
+    assert user.profile.name_visibility == VisibilityChoices.PUBLIC
+    assert user.profile.location_visibility == VisibilityChoices.PUBLIC
+    assert user.profile.bio_visibility == VisibilityChoices.PUBLIC
+    assert user.profile.phone_visibility == VisibilityChoices.PRIVATE
+    assert user.profile.friend_info_visibility == VisibilityChoices.FRIENDS
+    assert user.profile.music_preferences_visibility == VisibilityChoices.PUBLIC

--- a/apps/profile/tests/test_profile_serializer.py
+++ b/apps/profile/tests/test_profile_serializer.py
@@ -1,0 +1,46 @@
+import pytest
+from apps.users.tests.conftest import authenticated_user
+from apps.profile.models import VisibilityChoices, MusicPreference
+from apps.profile.serializers import ProfileSerializer
+
+
+@pytest.mark.django_db
+def test_profile_serializer(authenticated_user):
+
+    user, _ = authenticated_user
+    
+    mp1 = MusicPreference.objects.create(name="rock")
+    mp2 = MusicPreference.objects.create(name="jazz")
+
+    user.profile.avatar = "user123_xxx.png"
+    user.profile.name = "user123"
+    user.profile.name_visibility = VisibilityChoices.PUBLIC
+    user.profile.location = "SUTD"
+    user.profile.location_visibility = VisibilityChoices.PUBLIC
+    user.profile.bio = "Hello !"
+    user.profile.bio_visibility = VisibilityChoices.PUBLIC
+    user.profile.phone = "+6591234567"
+    user.profile.phone_visibility = VisibilityChoices.PRIVATE
+    user.profile.friend_info = "Hello Friend !"
+    user.profile.friend_info_visibility = VisibilityChoices.FRIENDS
+    user.profile.music_preferences.add(mp1, mp2)
+    user.profile.music_preferences_visibility = VisibilityChoices.FRIENDS
+    user.profile.save()
+
+    serializer = ProfileSerializer(user.profile)
+    data = serializer.data
+
+    assert data["avatar"] == "/apps/profile/avatars/user123_xxx.png"
+    assert data["name"] == "user123"
+    assert data["location"] == "SUTD"
+    assert data["bio"] == "Hello !"
+    assert data["phone"] == "+6591234567"
+    assert data["friend_info"] == "Hello Friend !"
+    assert set(data["music_preferences"]) == {"rock", "jazz"}
+    assert data["name_visibility"] == VisibilityChoices.PUBLIC
+    assert data["location_visibility"] == VisibilityChoices.PUBLIC
+    assert data["bio_visibility"] == VisibilityChoices.PUBLIC
+    assert data["phone_visibility"] == VisibilityChoices.PRIVATE
+    assert data["friend_info_visibility"] == VisibilityChoices.FRIENDS
+    assert data["music_preferences_visibility"] == VisibilityChoices.FRIENDS
+

--- a/apps/profile/tests/test_profile_update.py
+++ b/apps/profile/tests/test_profile_update.py
@@ -1,0 +1,99 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.profile.tests.conftest import user_init_profile, make_image_file
+import uuid
+from apps.profile.models import VisibilityChoices, MusicPreference
+
+
+def test_update_profile_unauthenticated():
+    """
+        # Unauthenticated user
+        # Ensure response error {'detail': 'Authentication credentials were not provided.'}
+    """
+    client = APIClient()
+    url = reverse("profile:profile-update")
+
+    response = client.patch(url)
+    assert response.status_code == 401
+    assert response.json() == {'detail': 'Authentication credentials were not provided.'}
+    
+    response = client.put(url)
+    assert response.status_code == 401
+    assert response.json() == {'detail': 'Authentication credentials were not provided.'}
+
+
+@pytest.mark.django_db
+def test_update_profile_upload_avatar(authenticated_user):
+    """
+        # Upload a PNG image
+        # Ensure response avatar is not empty
+    """
+    image = make_image_file()
+
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse("profile:profile-update")
+
+    payload = {
+        "avatar": image
+    }
+
+    response = client.patch(url, payload, format="multipart")
+    assert response.status_code == 200
+    data = response.json()
+    assert "avatar" in data
+    assert data["avatar"]
+
+
+@pytest.mark.django_db
+def test_update_profile(authenticated_user):
+    """
+        # Valid payload
+        # Ensure response contains all inputs in payload
+    """
+    image = make_image_file()
+
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    url = reverse("profile:profile-update")
+
+    MusicPreference.objects.create(name="rock")
+    prefs = MusicPreference.objects.filter(name="rock").first()
+
+    payload = {
+        "avatar": image,
+        "name": "user248",
+        "name_visibility": VisibilityChoices.PRIVATE,
+        "location": "Singapore",
+        "location_visibility": VisibilityChoices.PUBLIC,
+        "bio": "bio",
+        "bio_visibility": VisibilityChoices.PUBLIC,
+        "phone": "+6598989898",
+        "phone_visibility": VisibilityChoices.PRIVATE,
+        "friend_info": "Hello Friend !",
+        "friend_info_visibility": VisibilityChoices.FRIENDS,
+        "music_preferences_ids": prefs.id,
+        "music_preferences_visibility": VisibilityChoices.PUBLIC
+    }
+
+    response = client.patch(url, payload, format="multipart")
+    assert response.status_code == 200
+    data = response.json()
+    assert "avatar" in data
+    assert data["avatar"]
+    assert data["name"] == "user248"
+    assert data["name_visibility"] == VisibilityChoices.PRIVATE
+    assert data["location"] == "Singapore"
+    assert data["location_visibility"] == VisibilityChoices.PUBLIC
+    assert data["bio"] == "bio"
+    assert data["bio_visibility"] == VisibilityChoices.PUBLIC
+    assert data["phone"] == "+6598989898"
+    assert data["phone_visibility"] == VisibilityChoices.PRIVATE
+    assert data["friend_info"] == "Hello Friend !"
+    assert data["friend_info_visibility"] == VisibilityChoices.FRIENDS
+    assert 'rock' in set(data["music_preferences"])
+    assert data["music_preferences_visibility"] == VisibilityChoices.PUBLIC

--- a/apps/profile/urls.py
+++ b/apps/profile/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from .views import profile_detail, profile_update, delete_avatar,music_preferences_list
 
+app_name = "profile"
+
 urlpatterns = [
     #path('', profile_list, name='profile-list'), #to do later ?
     path('<uuid:pk>/', profile_detail, name='profile-detail'),

--- a/apps/profile/views.py
+++ b/apps/profile/views.py
@@ -9,7 +9,10 @@ from .utils import can_view_field
 from django.shortcuts import get_object_or_404
 from .models import Profile, MusicPreference
 from rest_framework.decorators import api_view, authentication_classes
+from .docs import *
 
+
+@profile_update_schema
 @api_view(['PUT', 'PATCH'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -24,6 +27,7 @@ def profile_update(request):
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+@profile_detail_schema
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -64,6 +68,7 @@ def profile_detail(request, pk):
     return Response(data)
 
 
+@delete_avatar_schema
 @api_view(['DELETE'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -75,6 +80,7 @@ def delete_avatar(request):
     return Response({'detail': 'No avatar to delete.'}, status=400)
 
 
+@music_preferences_list_schema
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])

--- a/apps/users/tests/conftest.py
+++ b/apps/users/tests/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 from rest_framework.authtoken.models import Token
 from django.contrib.auth import get_user_model
+from apps.profile.models import Profile
+
 
 User = get_user_model()
 
@@ -12,5 +14,6 @@ def authenticated_user(db):
         email="user123@example.com",
         password="somePassword123"
     )
+    Profile.objects.create(user=user)
     token, _ = Token.objects.get_or_create(user=user)
     return user, token.key


### PR DESCRIPTION
Back-end
Add swagger API documentation to Profile.
Add pytest to profile.
Modify apps/users/tests/conftest.py to add profile creation during user creation.