### PR TITLE
Add swagger+pytest to friends APIs

### DIFF
--- a/apps/users/docs.py
+++ b/apps/users/docs.py
@@ -1,4 +1,4 @@
-from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample, OpenApiParameter
 from .docs_serializers import *
 
 
@@ -361,4 +361,315 @@ check_email_schema = extend_schema(
             response=CheckEmailResponseSerializer
         ),
     },
+)
+
+
+send_friend_request_schema = extend_schema(
+    methods=["POST"],
+    summary="Send a friend request",
+    parameters=[
+        OpenApiParameter(
+            name="user_id",
+            description="UUID of the user to send friend request to",
+            required=True,
+            location=OpenApiParameter.PATH,
+            type=str,
+            pattern=r'^[0-9a-fA-F-]{36}$',
+        ),
+    ],
+    request=None,
+    responses={
+        201: OpenApiResponse(
+            description="Friend request successfully sent",
+            response=FriendRequestResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Success",
+                    value={
+                        "message": "Friend request sent to user123.",
+                        "friend_id": "550e8400-e29b-41d4-a716-446655440000",
+                        "friendship_id": 1
+                    },
+                ),
+            ]
+        ),
+        400: OpenApiResponse(
+            description="Invalid friend request",
+            response=ErrorMessageSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Self Request",
+                    value={"message": "You cannot add yourself as a friend."}
+                ),
+                OpenApiExample(
+                    name="Pending Request",
+                    value={"message": "You already have a pending friend request."}
+                ),
+                OpenApiExample(
+                    name="Already Friends",
+                    value={"message": "You are already friends."}
+                ),
+            ]
+        ),
+        404: OpenApiResponse(
+            description="User not found",
+            response=ErrorMessageSerializer,
+            examples=[
+                OpenApiExample(
+                    name="User Not Found",
+                    value={"message": "Not found."}
+                )
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+accept_friend_request_schema = extend_schema(
+    methods=["POST"],
+    summary="Accept a pending friend request",
+    parameters=[
+        OpenApiParameter(
+            name="friendship_id",
+            description="ID of the pending friendship request to accept",
+            required=True,
+            location=OpenApiParameter.PATH,
+            type=int,
+        ),
+    ],
+    request=None,
+    responses={
+        200: OpenApiResponse(
+            description="Friend request accepted successfully",
+            response=AcceptFriendRequestResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Success",
+                    value={"message": "You are now friends with user123!"}
+                )
+            ]
+        ),
+        404: OpenApiResponse(
+            description="Friend request not found or not pending",
+            response=ErrorMessageSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Not Found",
+                    value={"message": "Not found."}
+                )
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+get_pending_friend_request_schema = extend_schema(
+    methods=["GET"],
+    summary="Get pending friend requests received by the authenticated user",
+    responses={
+        200: OpenApiResponse(
+            description="List of pending friend requests",
+            response=PendingFriendRequestsResponseSerializer
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+reject_friend_request_schema = extend_schema(
+    methods=["POST"],
+    summary="Reject a pending friend request",
+    parameters=[
+        OpenApiParameter(
+            name="friendship_id",
+            description="ID of the pending friendship request to reject",
+            required=True,
+            location=OpenApiParameter.PATH,
+            type=int,
+        ),
+    ],
+    request=None,
+    responses={
+        200: OpenApiResponse(
+            description="Friend request rejected successfully",
+            response=RejectFriendRequestResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Success",
+                    value={"message": "Friend request with user123 rejected!"}
+                )
+            ]
+        ),
+        404: OpenApiResponse(
+            description="Friend request not found or not pending",
+            response=ErrorMessageSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Not Found",
+                    value={"message": "Not found."}
+                )
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+get_sent_friend_request_schema = extend_schema(
+    methods=["GET"],
+    summary="Get pending friend requests sent by the authenticated user",
+    responses={
+        200: OpenApiResponse(
+            description="List of pending friend requests sent by user",
+            response=SentFriendRequestsResponseSerializer
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+get_friends_list_schema = extend_schema(
+    methods=["GET"],
+    summary="Get list of friends for the authenticated user",
+    responses={
+        200: OpenApiResponse(
+            description="List of friends",
+            response=FriendsListResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Friends List Example",
+                    value={
+                        "friends": [
+                            {
+                                "friend_id": "550e8400-e29b-41d4-a716-446655440000",
+                                "friend_username": "user123",
+                                "profile_picture_url": "http://example.com/media/user123.jpg"
+                            },
+                            {
+                                "friend_id": "123e4567-e89b-12d3-a456-426614174000",
+                                "friend_username": "user248",
+                                "profile_picture_url": ""
+                            }
+                        ]
+                    }
+                )
+            ]
+        ),
+        400: OpenApiResponse(
+            description="Error retrieving friends list",
+            response=ErrorResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Error Example",
+                    value={"error": "Detailed error message here."}
+                )
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+remove_friend_schema = extend_schema(
+    methods=["POST"],
+    summary="Remove a friend",
+    parameters=[
+        OpenApiParameter(
+            name="user_id",
+            description="UUID of the friend to remove",
+            required=True,
+            location=OpenApiParameter.PATH,
+            type=str,
+            pattern=r'^[0-9a-fA-F-]{36}$',
+        ),
+    ],
+    request=None,
+    responses={
+        200: OpenApiResponse(
+            description="Friend removed successfully",
+            response=RemoveFriendResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Success",
+                    value={"message": "Friend removed successfully."}
+                )
+            ]
+        ),
+        400: OpenApiResponse(
+            description="Not friend error",
+            response=ErrorMessageSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Not Friend",
+                    value={"message": "You are not friends with this user."}
+                )
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
 )

--- a/apps/users/docs_serializers.py
+++ b/apps/users/docs_serializers.py
@@ -11,6 +11,9 @@ class ErrorDetailSerializer(serializers.Serializer):
 class UnauthorizedResponseSerializer(serializers.Serializer):
     detail = serializers.CharField()
 
+class ErrorMessageSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
 
 #forgot_password_schema
 class ForgotPasswordRequestSerializer(serializers.Serializer):
@@ -117,3 +120,59 @@ class CheckEmailRequestSerializer(serializers.Serializer):
 
 class CheckEmailResponseSerializer(serializers.Serializer):
     exists = serializers.BooleanField()
+
+
+#send_friend_request
+class FriendRequestResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()
+    friend_id = serializers.UUIDField()
+    friendship_id = serializers.IntegerField()
+
+
+#accept_friend_request
+class AcceptFriendRequestResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
+
+#get_pending_friend_request
+class PendingFriendRequestSerializer(serializers.Serializer):
+    friend_id = serializers.UUIDField()
+    friend_username = serializers.CharField()
+    friendship_id = serializers.IntegerField()
+    profile_picture_url = serializers.CharField(allow_blank=True, required=False)
+    status = serializers.CharField()
+
+class PendingFriendRequestsResponseSerializer(serializers.Serializer):
+    received_invitations = PendingFriendRequestSerializer(many=True)
+
+
+#reject_friend_request
+class RejectFriendRequestResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
+
+#get_sent_friend_request
+class SentFriendRequestSerializer(serializers.Serializer):
+    friend_id = serializers.UUIDField()
+    friend_username = serializers.CharField()
+    friendship_id = serializers.IntegerField()
+    profile_picture_url = serializers.CharField(allow_blank=True, required=False)
+    status = serializers.CharField()
+
+class SentFriendRequestsResponseSerializer(serializers.Serializer):
+    sent_invitations = SentFriendRequestSerializer(many=True)
+
+
+#get_friends_list
+class FriendSerializer(serializers.Serializer):
+    friend_id = serializers.IntegerField()
+    friend_username = serializers.CharField()
+    profile_picture_url = serializers.CharField(allow_blank=True, required=False)
+
+class FriendsListResponseSerializer(serializers.Serializer):
+    friends = FriendSerializer(many=True)
+
+
+#remove_friend
+class RemoveFriendResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()

--- a/apps/users/tests/test_accept_friend_request.py
+++ b/apps/users/tests/test_accept_friend_request.py
@@ -1,0 +1,53 @@
+import pytest
+from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from apps.users.tests.conftest import authenticated_user
+from apps.users.models import Friendship
+
+
+User = get_user_model()
+
+@pytest.mark.django_db
+def test_accept_friend_request_success(authenticated_user):
+    """
+        # Accept a pending friend request
+        # Ensure response {'message': 'You are now friends with friend123!'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    friendship = Friendship.objects.create(
+        from_user=friend,
+        to_user=user,
+        status="pending"
+    )
+
+    url = reverse("users:accept_friend_request", args=[friendship.id])
+    response = client.post(url)
+    assert response.status_code == 200
+    assert response.json() == {'message': 'You are now friends with friend123!'}
+
+
+@pytest.mark.django_db
+def test_accept_friend_request_not_found(authenticated_user):
+    """
+        # Accept a non exists friendship request
+        # Ensure response error {'detail': 'No Friendship matches the given query.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    url = reverse("users:accept_friend_request", args=[999])
+    response = client.post(url)
+    assert response.status_code == 404
+    assert response.json() == {'detail': 'No Friendship matches the given query.'}

--- a/apps/users/tests/test_get_friends.py
+++ b/apps/users/tests/test_get_friends.py
@@ -1,0 +1,71 @@
+import pytest
+from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from apps.users.tests.conftest import authenticated_user
+from apps.users.models import Friendship
+from uuid import UUID
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_get_friends_success(authenticated_user):
+    """
+        # List all 'accepted' friends
+        # Ensure response matches friend details
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    Friendship.objects.create(
+        from_user=friend,
+        to_user=user,
+        status="accepted"
+    )
+
+    url = reverse("users:get_friends")
+    response = client.get(url)
+    assert response.status_code == 200
+    result = response.json()
+
+    result = result["friends"][0]
+    assert UUID(result["friend_id"]) == friend.id
+    assert result["friend_username"] == friend.username
+
+
+@pytest.mark.django_db
+def test_get_friends_no_friends(authenticated_user):
+    """
+        # List if no 'accepted' friends
+        # Ensure response {'friends': []}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    Friendship.objects.create(
+        from_user=friend,
+        to_user=user,
+        status="pending"
+    )
+
+    url = reverse("users:get_friends")
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.json() == {'friends': []}

--- a/apps/users/tests/test_get_pending_friend_request.py
+++ b/apps/users/tests/test_get_pending_friend_request.py
@@ -1,0 +1,39 @@
+import pytest
+from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from apps.users.tests.conftest import authenticated_user
+from apps.users.models import Friendship
+from uuid import UUID
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_get_pending_friend_request_success(authenticated_user):
+    """
+        # Get user current pending friend request
+        # Ensure response contains matching friend details
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    Friendship.objects.create(from_user=friend, to_user=user, status="pending")
+
+    url = reverse("users:get_pending_friend_request")
+    response = client.get(url)
+    assert response.status_code == 200
+    result = response.json()
+
+    result = result["received_invitations"][0]
+    assert UUID(result["friend_id"]) == friend.id
+    assert result["friend_username"] == friend.username

--- a/apps/users/tests/test_get_sent_friend_request.py
+++ b/apps/users/tests/test_get_sent_friend_request.py
@@ -1,0 +1,43 @@
+import pytest
+from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from apps.users.tests.conftest import authenticated_user
+from apps.users.models import Friendship
+from uuid import UUID
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_get_sent_friend_request_success(authenticated_user):
+    """
+        # Current sent friend request list
+        # Ensure response contains matching friend details
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    url = reverse("users:send_friend_request", args=[friend.id])
+    response = client.post(url)
+    assert response.status_code == 201
+    result = response.json()
+    assert result["message"] == 'Friend request sent to friend123.'
+
+    url = reverse("users:get_sent_friend_request")
+    response = client.get(url)
+    assert response.status_code == 200
+    result = response.json()
+
+    result = result["sent_invitations"][0]
+    assert UUID(result["friend_id"]) == friend.id
+    assert result["friend_username"] == friend.username

--- a/apps/users/tests/test_reject_friend_request.py
+++ b/apps/users/tests/test_reject_friend_request.py
@@ -1,0 +1,54 @@
+import pytest
+from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from apps.users.tests.conftest import authenticated_user
+from apps.users.models import Friendship
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_reject_friend_request_success(authenticated_user):
+    """
+        # Reject a friend request
+        # Ensure response {'message': 'Friend request with friend123 rejected!'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    friendship = Friendship.objects.create(
+        from_user=friend,
+        to_user=user,
+        status="pending"
+    )
+
+    url = reverse("users:reject_friend_request", args=[friendship.id])
+    response = client.post(url)
+    assert response.status_code == 200
+    assert response.json() == {'message': 'Friend request with friend123 rejected!'}
+
+
+@pytest.mark.django_db
+def test_reject_friend_request_not_found(authenticated_user):
+    """
+        # Reject a non exists friendship request
+        # Ensure response error {'detail': 'No Friendship matches the given query.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    url = reverse("users:reject_friend_request", args=[999])
+    response = client.post(url)
+    assert response.status_code == 404
+    assert response.json() == {'detail': 'No Friendship matches the given query.'}

--- a/apps/users/tests/test_remove_friend.py
+++ b/apps/users/tests/test_remove_friend.py
@@ -1,0 +1,67 @@
+import pytest
+from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from apps.users.tests.conftest import authenticated_user
+from apps.users.models import Friendship
+from uuid import UUID
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_remove_friend_success(authenticated_user):
+    """
+        # Remove a friend
+        # Ensure response {'message': 'Friend removed successfully.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    Friendship.objects.create(
+        from_user=friend,
+        to_user=user,
+        status="accepted"
+    )
+
+    url = reverse("users:remove_friend", args=[friend.id])
+    response = client.post(url)
+    assert response.status_code == 200
+    assert response.json() == {'message': 'Friend removed successfully.'}
+
+
+@pytest.mark.django_db
+def test_remove_friend_no_friend(authenticated_user):
+    """
+        # Remove a non-existant friend
+        # Ensure response error {'message': 'You are not friends with this user.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    Friendship.objects.create(
+        from_user=friend,
+        to_user=user,
+        status="pending"
+    )
+
+    url = reverse("users:remove_friend", args=[friend.id])
+    response = client.post(url)
+    assert response.status_code == 400
+    assert response.json() == {'message': 'You are not friends with this user.'}

--- a/apps/users/tests/test_send_friend_request.py
+++ b/apps/users/tests/test_send_friend_request.py
@@ -1,0 +1,108 @@
+import pytest
+from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from apps.users.tests.conftest import authenticated_user
+from apps.users.models import Friendship
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_send_friend_request_success(authenticated_user):
+    """
+        # Success sent friend request
+        # Ensure response contains - 'Friend request sent to friend123.'
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    url = reverse("users:send_friend_request", args=[friend.id])
+
+    response = client.post(url)
+    assert response.status_code == 201
+    result = response.json()
+    assert result["message"] == 'Friend request sent to friend123.'
+
+
+@pytest.mark.django_db
+def test_send_friend_request_cannot_add_self(authenticated_user):
+    """
+        # Send friend request using own id
+        # Ensure response error {'message': 'You cannot add yourself as a friend.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    url = reverse("users:send_friend_request", args=[user.id])
+
+    response = client.post(url)
+    assert response.status_code == 400
+    assert response.json() == {'message': 'You cannot add yourself as a friend.'}
+
+
+@pytest.mark.django_db
+def test_send_friend_request_already_pending(authenticated_user):
+    """
+        # Resend same friend id request
+        # Ensure response error {'message': 'You already have a pending friend request.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    url = reverse("users:send_friend_request", args=[friend.id])
+    response = client.post(url)
+    assert response.status_code == 201
+    result = response.json()
+    assert result["message"] == 'Friend request sent to friend123.'
+
+    #send again same friend id
+    url = reverse("users:send_friend_request", args=[friend.id])
+    response = client.post(url)
+    assert response.status_code == 400
+    assert response.json() == {'message': 'You already have a pending friend request.'}
+
+
+@pytest.mark.django_db
+def test_send_friend_request_already_friend(authenticated_user):
+    """
+        # Send a user id that is already a friend
+        # Ensure response error {'message': 'You are already friends.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    Friendship.objects.create(
+        from_user=user,
+        to_user=friend,
+        status="accepted"
+    )
+
+    url = reverse("users:send_friend_request", args=[friend.id])
+    response = client.post(url)
+    assert response.status_code == 400
+    assert response.json() == {'message': 'You are already friends.'}

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -128,6 +128,7 @@ def check_email(request):
     return JsonResponse({'exists': email_exists}, status=status.HTTP_200_OK)
 
 
+@remove_friend_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -142,6 +143,8 @@ def remove_friend(request, user_id):
     friendship.delete()
     return JsonResponse({'message': 'Friend removed successfully.'}, status=status.HTTP_200_OK)
 
+
+@get_friends_list_schema
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -174,6 +177,7 @@ def get_friends_list(request):
     except Exception as e:
         return Response({'error': str(e)}, status=400)
 
+@send_friend_request_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -197,6 +201,7 @@ def send_friend_request(request, user_id):
     }, status=201)
 
 
+@get_pending_friend_request_schema
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -226,6 +231,7 @@ def get_pending_friend_request(request):
     return JsonResponse({'received_invitations': data}, status=200)
 
 
+@get_sent_friend_request_schema
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -257,6 +263,7 @@ def get_sent_friend_request(request):
     return JsonResponse({'sent_invitations': data}, status=200)
 
 
+@accept_friend_request_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -269,6 +276,7 @@ def accept_friend_request(request, friendship_id):
     }, status=200)
 
 
+@reject_friend_request_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])


### PR DESCRIPTION
Back-end
Add swagger and pytest to friends APIs:

path('send_friend_request/<uuid:user_id>/', views.send_friend_request, name='send_friend_request'),
path('invitations/sent/', views.get_sent_friend_request, name='get_sent_friend_request'),
path('invitations/received/', views.get_pending_friend_request, name='get_pending_friend_request'),    
path('accept_friend_request/<int:friendship_id>/', views.accept_friend_request, name='accept_friend_request'),
path('reject_friend_request/<int:friendship_id>/', views.reject_friend_request, name='reject_friend_request'),
path('get_friends/', views.get_friends_list, name='get_friends'),
path('remove_friend/<uuid:user_id>/', views.remove_friend, name='remove_friend'),
