### PR TITLE
added swagger+pytest to playlists APIs

### DIFF
--- a/apps/playlists/docs.py
+++ b/apps/playlists/docs.py
@@ -1,0 +1,734 @@
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample, OpenApiParameter
+from .docs_serializers import *
+from apps.playlists.serializers import PlaylistLicenseSerializer
+
+
+create_new_playlist_schema = extend_schema(
+    methods=["POST"],
+    summary="Create a new playlist",
+    request=PlaylistCreateRequestSerializer,
+    responses={
+        201: OpenApiResponse(
+            response=PlaylistCreateResponseSerializer,
+            description="Playlist successfully created",
+            examples=[
+                OpenApiExample(
+                    "Success",
+                    value={
+                        "message": "Empty playlist is created.",
+                        "playlist_id": 1
+                    }
+                )
+            ],
+        ),
+        400: OpenApiResponse(
+            description="Missing Name",
+            response=ErrorResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    "Missing name",
+                    value={"error": "Playlist name is required."}
+                )
+            ],
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    },
+)
+
+
+get_playlist_info_schema = extend_schema(
+    methods=["GET"],
+    summary="Get playlist details",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            required=True,
+            location=OpenApiParameter.PATH,
+            type=int,
+        )
+    ],
+    responses={
+        200: OpenApiResponse(
+            response=PlaylistInfoResponseSerializer,
+            description="Playlist details retrieved successfully",
+            examples=[
+                OpenApiExample(
+                    "Success",
+                    value={
+                        "playlist": [
+                            {
+                                "id": 1,
+                                "playlist_name": "My Favorites",
+                                "description": "All my favorite songs",
+                                "public": True,
+                                "creator": "user248",
+                                "license_type": "open",
+                                "tracks": [
+                                    {"name": "Imagine", "artist": "John Lennon"},
+                                    {"name": "Hey Jude", "artist": "The Beatles"}
+                                ],
+                                "shared_with": [
+                                    {"id": "d2f1e240-bb4b-4b6a-bf62-aba9f915b111", "username": "user123"}
+                                ]
+                            }
+                        ]
+                    }
+                )
+            ]
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Playlist not found",
+            examples=[
+                OpenApiExample(
+                    name="Not Found",
+                    value={"error": "Playlist not found."}
+                ),
+                OpenApiExample(
+                    name="Not Found Playlist",
+                    value={"detail": "No Playlist matches the given query."}
+                ),
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+update_playlist_schema = extend_schema(
+    methods=["PATCH"],
+    summary="Update an existing playlist",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            location=OpenApiParameter.PATH,
+            type=int,
+            required=True,
+        )
+    ],
+    request=PlaylistUpdateSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=PlaylistUpdateResponseSerializer,
+            description="Playlist updated successfully",
+            examples=[
+                OpenApiExample(
+                    "Success Example",
+                    value={"message": "Playlist updated successfully."}
+                )
+            ]
+        ),
+        403: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="User does not have permission to update this playlist",
+            examples=[
+                OpenApiExample(
+                    "Permission Denied",
+                    value={"error": "You do not have permission to edit this playlist."}
+                )
+            ]
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Playlist not found",
+            examples=[
+                OpenApiExample(
+                    "Not Found",
+                    value={"error": "Not found."}
+                ),
+                OpenApiExample(
+                    name="Not Found Playlist",
+                    value={"detail": "No Playlist matches the given query."}
+                ),
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+delete_playlist_schema = extend_schema(
+    methods=["POST"],
+    summary="Delete a playlist",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            location=OpenApiParameter.PATH,
+            type=int,
+            required=True,
+        )
+    ],
+    responses={
+        200: OpenApiResponse(
+            response=PlaylistDeleteResponseSerializer,
+            description="Playlist deleted successfully",
+            examples=[
+                OpenApiExample(
+                    "Success",
+                    value={"message": "Playlist deleted successfully."}
+                )
+            ]
+        ),
+        403: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="User does not have permission to delete this playlist",
+            examples=[
+                OpenApiExample(
+                    "Permission Denied",
+                    value={"error": "You do not have permission to delete this playlist."}
+                )
+            ]
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Playlist not found",
+            examples=[
+                OpenApiExample(
+                    "Not Found",
+                    value={"error": "Not found."}
+                ),
+                OpenApiExample(
+                    name="Not Found Playlist",
+                    value={"detail": "No Playlist matches the given query."}
+                ),
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+playlist_tracks_schema = extend_schema(
+    methods=["GET"],
+    summary="Get playlist tracks",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            location=OpenApiParameter.PATH,
+            type=int,
+            required=True,
+        )
+    ],
+    responses={
+        200: OpenApiResponse(
+            response=PlaylistTracksResponseSerializer,
+            description="Playlist and its tracks retrieved successfully",
+            examples=[
+                OpenApiExample(
+                    "Success",
+                    value={
+                        "playlist": "My Playlist",
+                        "tracks": [
+                            {
+                                "track_id": 1,
+                                "playlist_track_id": 10,
+                                "deezer_track_id": "123456",
+                                "name": "Track Title",
+                                "position": 1,
+                                "points": 0
+                            },
+                            {
+                                "track_id": 2,
+                                "playlist_track_id": 11,
+                                "deezer_track_id": "654321",
+                                "name": "Another Track",
+                                "position": 2,
+                                "points": 0
+                            }
+                        ]
+                    }
+                )
+            ]
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Playlist not found",
+            examples=[
+                OpenApiExample(
+                    "Not Found",
+                    value={"error": "Not found."}
+                ),
+                OpenApiExample(
+                    name="Not Found Playlist",
+                    value={"detail": "No Playlist matches the given query."}
+                ),
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+add_track_schema = extend_schema(
+    methods=["POST"],
+    summary="Add track to playlist",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            location=OpenApiParameter.PATH,
+            type=int,
+            required=True,
+        )
+    ],
+    request=AddTrackRequestSerializer,
+    responses={
+        201: OpenApiResponse(
+            response=AddTrackSuccessSerializer,
+            description="Track successfully added to playlist",
+            examples=[
+                OpenApiExample(
+                    "Success",
+                    value={"status": "track added", "track_id": 42}
+                )
+            ]
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="General error or track already in playlist",
+            examples=[
+                OpenApiExample("Already Exists", value={"error": "Track already in playlist"}),
+                OpenApiExample("General Error", value={"error": "Some validation error"})
+            ]
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Playlist or Deezer track not found",
+            examples=[
+                OpenApiExample("Playlist Missing", value={"error": "Playlist not found"}),
+                OpenApiExample("Deezer Missing", value={"error": "Track not found on Deezer"})
+            ]
+        ),
+        405: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Method not allowed",
+            examples=[
+                OpenApiExample("Invalid Method", value={"error": "Invalid method"})
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+move_track_in_playlist_schema = extend_schema(
+    methods=["POST"],
+    summary="Reorder tracks in a playlist",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            location=OpenApiParameter.PATH,
+            type=int,
+            required=True,
+        )
+    ],
+    request=MoveTrackRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=MoveTrackSuccessSerializer,
+            description="Tracks successfully reordered",
+            examples=[
+                OpenApiExample(
+                    "Success",
+                    value={"message": "Tracks reordered successfully"}
+                )
+            ]
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Invalid input or general error",
+            examples=[
+                OpenApiExample("Invalid Range", value={"error": "Invalid range"}),
+                OpenApiExample("General Error", value={"error": "Some validation error"})
+            ]
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Playlist not found",
+            examples=[
+                OpenApiExample("Playlist Missing", value={"error": "Playlist not found"})
+            ]
+        ),
+        405: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Method not allowed",
+            examples=[
+                OpenApiExample("Invalid Method", value={"error": "Invalid method"})
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+delete_track_from_playlist_schema = extend_schema(
+    methods=["POST"],
+    summary="Delete a track from a playlist",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            location=OpenApiParameter.PATH,
+            type=int,
+            required=True,
+        )
+    ],
+    request=DeleteTrackRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=DeleteTrackSuccessSerializer,
+            description="Track successfully deleted from playlist",
+            examples=[
+                OpenApiExample(
+                    "Success",
+                    value={"message": "Track deleted successfully"}
+                )
+            ]
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="General error or invalid body)",
+            examples=[
+                OpenApiExample("Invalid Body", value={"error": "Invalid JSON"}),
+                OpenApiExample("General Error", value={"error": "Something went wrong"})
+            ]
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Playlist or track not found",
+            examples=[
+                OpenApiExample("Playlist Missing", value={"error": "Playlist not found"}),
+                OpenApiExample("Track Missing", value={"error": "Track not found in playlist"})
+            ]
+        ),
+        405: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Method not allowed",
+            examples=[
+                OpenApiExample("Invalid Method", value={"error": "Invalid method"})
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    }
+)
+
+
+get_user_saved_playlists_schema = extend_schema(
+    methods=["GET"],
+    summary="Get user saved or created playlists",
+    responses={
+        200: OpenApiResponse(
+            response=UserSavedPlaylistsResponseSerializer,
+            description="List of user saved or created playlists"
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    },
+)
+
+
+get_all_shared_playlists_schema = extend_schema(
+    methods=["GET"],
+    summary="Get all shared public playlists",
+    responses={
+        200: OpenApiResponse(
+            response=SharedPlaylistsResponseSerializer,
+            description="List of all shared public playlists"
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    },
+)
+
+
+change_visibility_schema = extend_schema(
+    methods=["POST"],
+    summary="Change playlist visibility",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            location=OpenApiParameter.PATH,
+            type=int,
+            required=True,
+        )
+    ],
+    request=ChangeVisibilityRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=ChangeVisibilityResponseSerializer,
+            description="Playlist visibility updated successfully",
+            examples=[
+                OpenApiExample(
+                    name="Success",
+                    value={"message": "Playlist visibility changed successfully"},
+                )
+            ]
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Invalid request or playlist not found",
+            examples=[
+                OpenApiExample(
+                    name="Not found",
+                    value={"error": "Playlist matching query does not exist."},
+                )
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    },
+)
+
+
+invite_user_schema = extend_schema(
+    methods=["POST"],
+    summary="Invite user to playlist",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            location=OpenApiParameter.PATH,
+            type=int,
+            required=True,
+        )
+    ],
+    request=InviteUserRequestSerializer,
+    responses={
+        201: OpenApiResponse(
+            response=InviteUserResponseSerializer,
+            description="User invited successfully",
+            examples=[
+                OpenApiExample(
+                    name="Success",
+                    value={"message": "User invited to the playlist"},
+                )
+            ]
+        ),
+        200: OpenApiResponse(
+            response=InviteUserResponseSerializer,
+            description="User already invited",
+            examples=[
+                OpenApiExample(
+                    name="Already invited",
+                    value={"message": "User already invited"},
+                )
+            ]
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="Invalid request"
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    },
+)
+
+
+patch_playlist_license_schema = extend_schema(
+    methods=["PATCH"],
+    summary="Update playlist license",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            location=OpenApiParameter.PATH,
+            type=int,
+            required=True,
+        )
+    ],
+    request=PlaylistLicenseSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=PlaylistLicenseSerializer,
+            description="Playlist license updated successfully"
+        ),
+        400: OpenApiResponse(
+            description="Invalid data provided"
+        ),
+        403: OpenApiResponse(
+            description="Permission denied or not the playlist creator",
+            response=ErrorDetailSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Permission denied",
+                    value={"detail": "You do not have permission to edit this playlist license."},
+                )
+            ]
+        ),
+        404: OpenApiResponse(
+            description="Playlist not found",
+            response=ErrorDetailSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Not found",
+                    value={"detail": "Playlist not found"},
+                )
+            ]
+        ), 
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+
+    },
+)
+
+
+vote_for_track_schema = extend_schema(
+    methods=["POST"],
+    summary="Vote for a track in a playlist",
+    parameters=[
+        OpenApiParameter(
+            name="playlist_id",
+            location=OpenApiParameter.PATH,
+            type=int,
+            required=True,
+        )
+    ],
+    request=VoteSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=PlaylistResponseSerializer,
+            description="Vote registered and playlist updated"
+        ),
+        400: OpenApiResponse(
+            description="Invalid data provided"
+        ),
+        403: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description="User has already voted in this playlist",
+            examples=[
+                OpenApiExample(
+                    name="Already voted",
+                    value={"error": "You have already voted for this playlist"},
+                )
+            ]
+        ),
+        404: OpenApiResponse(
+            description="Playlist not found",
+            response=ErrorDetailSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Not found",
+                    value={"detail": "Playlist not found"},
+                )
+            ]
+        ),
+        401: OpenApiResponse(
+            description="Unauthorized",
+            response=UnauthorizedResponseSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Unauthorized",
+                    value={"detail": "Authentication credentials were not provided."},
+                )
+            ]
+        ),
+    },
+)

--- a/apps/playlists/docs_serializers.py
+++ b/apps/playlists/docs_serializers.py
@@ -1,0 +1,171 @@
+from rest_framework import serializers
+
+
+#shared
+class ErrorResponseSerializer(serializers.Serializer):
+    error = serializers.CharField()
+
+class UnauthorizedResponseSerializer(serializers.Serializer):
+    detail = serializers.CharField()
+
+class ErrorDetailSerializer(serializers.Serializer):
+    detail = serializers.CharField()
+
+
+#create_new_playlist
+class PlaylistCreateRequestSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    description = serializers.CharField(required=False, allow_blank=True)
+    public = serializers.BooleanField(required=False, default=True)
+    license_type = serializers.CharField(required=False, default='open')
+
+
+class PlaylistCreateResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()
+    playlist_id = serializers.UUIDField()
+
+
+#get_playlist_info
+class TrackSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    artist = serializers.CharField()
+
+
+class SharedUserSerializer(serializers.Serializer):
+    id = serializers.UUIDField()
+    username = serializers.CharField()
+
+
+class PlaylistInfoSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    playlist_name = serializers.CharField()
+    description = serializers.CharField()
+    public = serializers.BooleanField()
+    creator = serializers.CharField()
+    license_type = serializers.CharField()
+    tracks = TrackSerializer(many=True)
+    shared_with = SharedUserSerializer(many=True)
+
+
+class PlaylistInfoResponseSerializer(serializers.Serializer):
+    playlist = PlaylistInfoSerializer(many=True)
+
+
+#update_playlist
+class PlaylistUpdateSerializer(serializers.Serializer):
+    name = serializers.CharField(required=False)
+    description = serializers.CharField(required=False)
+    public = serializers.BooleanField(required=False)
+    license_type = serializers.CharField(required=False)
+
+
+class PlaylistUpdateResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
+
+#delete_playlist
+class PlaylistDeleteResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
+
+#playlist_tracks
+class PlaylistTrackSerializer(serializers.Serializer):
+    track_id = serializers.IntegerField()
+    playlist_track_id = serializers.IntegerField()
+    deezer_track_id = serializers.IntegerField()
+    name = serializers.CharField()
+    position = serializers.IntegerField()
+    points = serializers.IntegerField()
+
+class PlaylistTracksResponseSerializer(serializers.Serializer):
+    playlist = serializers.CharField()
+    tracks = PlaylistTrackSerializer(many=True)
+
+
+#add_track
+class AddTrackRequestSerializer(serializers.Serializer):
+    track_id = serializers.IntegerField()
+
+class AddTrackSuccessSerializer(serializers.Serializer):
+    status = serializers.CharField()
+    track_id = serializers.IntegerField()
+
+
+#move_track_in_playlist
+class MoveTrackRequestSerializer(serializers.Serializer):
+    range_start = serializers.IntegerField()
+    insert_before = serializers.IntegerField()
+    range_length = serializers.IntegerField()
+
+class MoveTrackSuccessSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
+
+#delete_track
+class DeleteTrackRequestSerializer(serializers.Serializer):
+    track_id = serializers.IntegerField()
+
+class DeleteTrackSuccessSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
+
+#get_user_saved_playlists
+class TrackSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    artist = serializers.CharField()
+
+class PlaylistSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    description = serializers.CharField(allow_blank=True, required=False)
+    public = serializers.BooleanField()
+    creator = serializers.CharField()
+    tracks = TrackSerializer(many=True)
+
+class UserSavedPlaylistsResponseSerializer(serializers.Serializer):
+    playlists = PlaylistSerializer(many=True)
+
+
+#get_all_shared_playlists
+class SharedPlaylistsResponseSerializer(serializers.Serializer):
+    playlists = PlaylistSerializer(many=True)
+
+
+#change_visibility
+class ChangeVisibilityRequestSerializer(serializers.Serializer):
+    public = serializers.BooleanField()
+
+class ChangeVisibilityResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
+
+#invite_user
+class InviteUserRequestSerializer(serializers.Serializer):
+    user_id = serializers.UUIDField()
+
+class InviteUserResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
+
+#patch_playlist_license
+
+#vote_for_track_schema
+class VoteSerializer(serializers.Serializer):
+    range_start = serializers.IntegerField()
+
+class PlaylistTrackSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    artist = serializers.CharField()
+    points = serializers.IntegerField()
+
+class PlaylistDataSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    playlist_name = serializers.CharField()
+    description = serializers.CharField(allow_blank=True, required=False)
+    public = serializers.BooleanField()
+    creator = serializers.CharField()
+    tracks = PlaylistTrackSerializer(many=True)
+
+class PlaylistResponseSerializer(serializers.Serializer):
+    playlist = PlaylistDataSerializer()
+

--- a/apps/playlists/tests/test_add_track.py
+++ b/apps/playlists/tests/test_add_track.py
@@ -1,0 +1,84 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist, Track, PlaylistTrack
+
+
+@pytest.mark.django_db
+def test_add_track_success(authenticated_user):
+    """
+        # Add a track to playlist
+        # Ensure get response matching track_id added
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+
+    payload = {
+        "track_id": track1.id
+    }
+
+    url = reverse("playlists:add_track", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 201
+    data = response.json()
+    assert data["track_id"] == track1.id
+
+
+@pytest.mark.django_db
+def test_add_track_already_exist(authenticated_user):
+    """
+        # Add a already exist track to playlist
+        # Ensure get response error {'error': 'Track already in playlist'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+
+    payload = {
+        "track_id": track1.id
+    }
+
+    url = reverse("playlists:add_track", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 201
+    data = response.json()
+    assert data["track_id"] == track1.id
+
+    #add again
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Track already in playlist'}

--- a/apps/playlists/tests/test_change_visibility.py
+++ b/apps/playlists/tests/test_change_visibility.py
@@ -1,0 +1,35 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist, Track, PlaylistTrack
+
+
+@pytest.mark.django_db
+def test_change_visibility_success(authenticated_user):
+    """
+        # Change visibility of playlist
+        # Ensure get response {'message': 'Playlist visibility changed successfully'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    payload = {
+        "public": False
+    }
+
+    url = reverse("playlists:change_visibility", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 200
+    assert response.json() == {'message': 'Playlist visibility changed successfully'}

--- a/apps/playlists/tests/test_delete_track_from_playlist.py
+++ b/apps/playlists/tests/test_delete_track_from_playlist.py
@@ -1,0 +1,78 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist, Track, PlaylistTrack
+
+
+@pytest.mark.django_db
+def test_delete_track_in_playlist_success(authenticated_user):
+    """
+        # Delete a track in a playlist
+        # Ensure get response {'message': 'Track deleted successfully'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+
+    PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track1,
+        position=0,
+        points=0
+    )
+
+    payload = {
+        "track_id": track1.id
+    }
+
+    url = reverse("playlists:remove_items", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 200
+    assert response.json() == {'message': 'Track deleted successfully'}
+
+
+@pytest.mark.django_db
+def test_delete_track_in_playlist_track_not_found(authenticated_user):
+    """
+        # Delete a invalid track in a playlist
+        # Ensure get response {'error': 'Track not found in playlist'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    payload = {
+        "track_id": 9999
+    }
+
+    url = reverse("playlists:remove_items", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 404
+    assert response.json() == {'error': 'Track not found in playlist'}

--- a/apps/playlists/tests/test_get_all_shared_playlists.py
+++ b/apps/playlists/tests/test_get_all_shared_playlists.py
@@ -1,0 +1,46 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist, Track, PlaylistTrack
+
+
+@pytest.mark.django_db
+def test_get_all_shared_playlist_success(authenticated_user):
+    """
+        # Get all public playlists
+        # Ensure get reponse matching playlist created
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+
+    PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track1,
+        position=0,
+        points=0
+    )
+
+    url = reverse("playlists:public_playlists")
+
+    response = client.get(url, format="json")
+    assert response.status_code == 200
+    data = response.json()
+    data = data["playlists"]
+    assert data[0]["id"] == playlist.id

--- a/apps/playlists/tests/test_get_playlist.py
+++ b/apps/playlists/tests/test_get_playlist.py
@@ -1,0 +1,50 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist
+
+
+@pytest.mark.django_db
+def test_get_playlist_info_success(authenticated_user):
+    """
+        # Get playlist info
+        # Ensure get response playlist id is same as created
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+            name="Fav999",
+            description="Fav999",
+            public=True,
+            license_type="open",
+            creator=user,
+            event=False
+        )
+    
+    url = reverse("playlists:get_playlist", args=[playlist.id])
+
+    response = client.get(url, format="json")
+    assert response.status_code == 200
+    data = response.json()
+    data = data["playlist"][0]
+    assert data["id"] == playlist.id
+
+
+@pytest.mark.django_db
+def test_get_playlist_info_not_found(authenticated_user):
+    """
+        # Get invalid playlist info
+        # Ensure get response error {'detail': 'No Playlist matches the given query.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    url = reverse("playlists:get_playlist", args=[9999])
+
+    response = client.get(url, format="json")
+    assert response.status_code == 404
+    assert response.json() == {'detail': 'No Playlist matches the given query.'}

--- a/apps/playlists/tests/test_get_user_saved_playlists.py
+++ b/apps/playlists/tests/test_get_user_saved_playlists.py
@@ -1,0 +1,46 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist, Track, PlaylistTrack
+
+
+@pytest.mark.django_db
+def test_get_user_saved_playlist_success(authenticated_user):
+    """
+        # Get user saved playlists
+        # Ensure get matching playlist as created
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+
+    PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track1,
+        position=0,
+        points=0
+    )
+
+    url = reverse("playlists:saved_playlists")
+
+    response = client.get(url, format="json")
+    assert response.status_code == 200
+    data = response.json()
+    data = data["playlists"]
+    assert data[0]["id"] == playlist.id

--- a/apps/playlists/tests/test_invite_user.py
+++ b/apps/playlists/tests/test_invite_user.py
@@ -1,0 +1,76 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist, Track, PlaylistTrack
+from django.contrib.auth import get_user_model
+from uuid import UUID
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_invite_user_success(authenticated_user):
+    """
+        # Invite user to playlist
+        # Ensure get response {'message': 'User invited to the playlist'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    friend = User.objects.create_user(
+        username="friend123",
+        email="friend123@example.com",
+        password="somePassword123"
+    )
+
+    payload = {
+        "user_id": friend.id
+    }
+
+    url = reverse("playlists:invite_user", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 201
+    assert response.json() == {'message': 'User invited to the playlist'}
+
+
+@pytest.mark.django_db
+def test_invite_user_not_found_user(authenticated_user):
+    """
+        # Invite invalid user to playlist
+        # Ensure get response error {'error': 'CustomUser matching query does not exist.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    payload = {
+        "user_id": 0
+    }
+
+    url = reverse("playlists:invite_user", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'CustomUser matching query does not exist.'}

--- a/apps/playlists/tests/test_move_track_in_playlist.py
+++ b/apps/playlists/tests/test_move_track_in_playlist.py
@@ -1,0 +1,117 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist, Track, PlaylistTrack
+
+
+@pytest.mark.django_db
+def test_move_track_in_playlist_success(authenticated_user):
+    """
+        # Move a track position in a playlist
+        # Ensure get response {'message': 'Tracks reordered successfully'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+    track2 = Track.objects.create(
+        name="Song B",
+        artist="Artist B",
+        deezer_track_id="1001"
+    )
+
+    PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track1,
+        position=0,
+        points=0
+    )
+    PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track2,
+        position=1,
+        points=0
+    )
+
+    payload = {
+        "range_start": 0,
+        "insert_before": 2,
+        "range_length": 1
+    }
+
+    url = reverse("playlists:move_track_in_playlist", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 200
+    assert response.json() == {'message': 'Tracks reordered successfully'}
+
+
+@pytest.mark.django_db
+def test_move_track_in_playlist_invalid_range(authenticated_user):
+    """
+        # Invalid range input
+        # Ensure get response error {'error': 'Invalid range'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+    track2 = Track.objects.create(
+        name="Song B",
+        artist="Artist B",
+        deezer_track_id="1001"
+    )
+
+    PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track1,
+        position=0,
+        points=0
+    )
+    PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track2,
+        position=1,
+        points=0
+    )
+
+    payload = {
+        "range_start": 100,
+        "insert_before": 2,
+        "range_length": 1
+    }
+
+    url = reverse("playlists:move_track_in_playlist", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Invalid range'}

--- a/apps/playlists/tests/test_patch_playlist_license.py
+++ b/apps/playlists/tests/test_patch_playlist_license.py
@@ -1,0 +1,96 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist, Track, PlaylistTrack
+
+
+@pytest.mark.django_db
+def test_patch_playlist_license_success(authenticated_user):
+    """
+        # Update playlist license
+        # Ensure get reponse matching the license type in payload
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    payload = {
+        "license_type": "invite_only"
+    }
+
+    url = reverse("playlists:patch_playlist_license", args=[playlist.id])
+
+    response = client.patch(url, payload, format="json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["license_type"] == "invite_only"
+
+
+@pytest.mark.django_db
+def test_patch_playlist_license_wrong_licence(authenticated_user):
+    """
+        # Update with invalid license type
+        # Ensure get reponse error {'license_type': ['"some_licence" is not a valid choice.']}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    payload = {
+        "license_type": "some_licence"
+    }
+
+    url = reverse("playlists:patch_playlist_license", args=[playlist.id])
+
+    response = client.patch(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'license_type': ['"some_licence" is not a valid choice.']}
+
+
+@pytest.mark.django_db
+def test_patch_playlist_license_not_found(authenticated_user):
+    """
+        # Update with invalid playlist
+        # Ensure get reponse error {'detail': 'Playlist not found'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    payload = {
+        "license_type": "invite_only"
+    }
+
+    url = reverse("playlists:patch_playlist_license", args=[9999])
+
+    response = client.patch(url, payload, format="json")
+    assert response.status_code == 404
+    assert response.json() == {'detail': 'Playlist not found'}

--- a/apps/playlists/tests/test_playlist_tracks.py
+++ b/apps/playlists/tests/test_playlist_tracks.py
@@ -1,0 +1,77 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist, Track, PlaylistTrack
+
+
+@pytest.mark.django_db
+def test_get_playlist_with_tracks(authenticated_user):
+    """
+        # Get tracks in playlist
+        # Ensure get response matching song tracks of the playlist
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+    track2 = Track.objects.create(
+        name="Song B",
+        artist="Artist B",
+        deezer_track_id="1001"
+    )
+
+    PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track1,
+        position=1,
+        points=0
+    )
+    PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track2,
+        position=2,
+        points=0
+    )
+
+    url = reverse("playlists:playlist_tracks", args=[playlist.id])
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["playlist"] == playlist.name
+    assert len(data["tracks"]) == 2
+    assert {t["name"] for t in data["tracks"]} == {"Song A", "Song B"}
+
+
+@pytest.mark.django_db
+def test_get_playlist_not_found(authenticated_user):
+    """
+        # Invalid playlist
+        # Ensure get response error {'detail': 'No Playlist matches the given query.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    url = reverse("playlists:playlist_tracks", args=[9999])
+
+    response = client.get(url)
+
+    assert response.status_code == 404
+    assert response.json() == {'detail': 'No Playlist matches the given query.'}

--- a/apps/playlists/tests/test_playlists.py
+++ b/apps/playlists/tests/test_playlists.py
@@ -1,0 +1,57 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist
+
+
+@pytest.mark.django_db
+def test_create_playlist_success(authenticated_user):
+    """
+        # Create a new empty playlist
+        # Ensure get status 201
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    url = reverse("playlists:playlists")
+
+    payload = {
+        "name": "Fav999",
+        "description": "Fav999",
+        "public": True,
+        "license_type": "open",
+        "event": False
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 201
+    data = response.json()
+    playlist = Playlist.objects.get(id=data["playlist_id"])
+    assert playlist.name == "Fav999"
+    assert playlist.creator == user
+
+
+@pytest.mark.django_db
+def test_create_playlist_missing_name(authenticated_user):
+    """
+        # Missing name in payload
+        # Ensure get error response {'error': 'Playlist name is required.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    url = reverse("playlists:playlists")
+
+    payload = {
+        "description": "No name provided",
+        "public": True,
+        "license_type": "open",
+        "event": False
+    }
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400, response.json()
+    assert response.json() == {'error': 'Playlist name is required.'}

--- a/apps/playlists/tests/test_update_playlist.py
+++ b/apps/playlists/tests/test_update_playlist.py
@@ -1,0 +1,60 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist
+
+
+@pytest.mark.django_db
+def test_get_update_playlist_success(authenticated_user):
+    """
+        # Update playlist
+        # Ensure get response {'message': 'Playlist updated successfully.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+            name="Fav999",
+            description="Fav999",
+            public=True,
+            license_type="open",
+            creator=user,
+            event=False
+        )
+    
+    payload = {
+        "name": "Fav123",
+        "description": "Fav123",
+        "public": False
+    }
+
+    url = reverse("playlists:update_playlist", args=[playlist.id])
+
+    response = client.patch(url, payload, format="json")
+    assert response.status_code == 200
+    assert response.json() == {'message': 'Playlist updated successfully.'}
+
+
+@pytest.mark.django_db
+def test_get_update_playlist_not_found(authenticated_user):
+    """
+        # Update invalid playlist
+        # Ensure get response error {'detail': 'No Playlist matches the given query.'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    
+    payload = {
+        "name": "Fav123",
+        "description": "Fav123",
+        "public": False
+    }
+
+    url = reverse("playlists:update_playlist", args=[9999])
+
+    response = client.patch(url, payload, format="json")
+    assert response.status_code == 404
+    assert response.json() == {'detail': 'No Playlist matches the given query.'}

--- a/apps/playlists/tests/test_vote_for_track.py
+++ b/apps/playlists/tests/test_vote_for_track.py
@@ -1,0 +1,140 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from apps.users.tests.conftest import authenticated_user
+from apps.playlists.models import Playlist, Track, PlaylistTrack
+
+
+@pytest.mark.django_db
+def test_vote_for_track_success(authenticated_user):
+    """
+        # Vote a track in a playlist
+        # Ensure get response - playlist track points increased by 1
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+
+    playlist_track = PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track1,
+        position=0,
+        points=0
+    )
+
+    payload = {
+        "range_start": 0
+    }
+
+    url = reverse("playlists:vote_for_track", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 200
+
+    pt = PlaylistTrack.objects.filter(playlist=playlist).first()
+    assert pt.points == 1
+
+
+@pytest.mark.django_db
+def test_vote_for_track_already_voted(authenticated_user):
+    """
+        # Vote a already voted track in a playlist
+        # Ensure get response error {'error': 'You have already voted for this playlist'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+
+    playlist_track = PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track1,
+        position=0,
+        points=0
+    )
+
+    payload = {
+        "range_start": 0
+    }
+
+    url = reverse("playlists:vote_for_track", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 200
+
+    # vote again
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 403
+    assert response.json() == {'error': 'You have already voted for this playlist'}
+
+
+@pytest.mark.django_db
+def test_vote_for_track_invalid_range(authenticated_user):
+    """
+        # Vote a invalid track in a playlist
+        # Ensure get response error {'error': 'Invalid track index'}
+    """
+    user, token = authenticated_user
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+    playlist = Playlist.objects.create(
+        name="Fav999",
+        description="Fav999",
+        public=True,
+        license_type="open",
+        creator=user,
+        event=False
+    )
+
+    track1 = Track.objects.create(
+        name="Song A",
+        artist="Artist A",
+        deezer_track_id="1000"
+    )
+
+    playlist_track = PlaylistTrack.objects.create(
+        playlist=playlist,
+        track=track1,
+        position=0,
+        points=0
+    )
+
+    payload = {
+        "range_start": 100
+    }
+
+    url = reverse("playlists:vote_for_track", args=[playlist.id])
+
+    response = client.post(url, payload, format="json")
+    assert response.status_code == 400
+    assert response.json() == {'error': 'Invalid track index'}

--- a/apps/playlists/urls.py
+++ b/apps/playlists/urls.py
@@ -1,6 +1,10 @@
 from django.urls import path
 from . import views
 
+
+app_name = "playlists"
+
+
 urlpatterns = [
     path('playlists', views.create_new_playlist, name='playlists'),
     path('playlists/<int:playlist_id>', views.get_playlist_info, name='get_playlist'),
@@ -9,13 +13,13 @@ urlpatterns = [
     path('playlists/<int:playlist_id>/remove_tracks', views.delete_track_from_playlist, name='remove_items'),
     path('saved_playlists/', views.get_user_saved_playlists, name='saved_playlists'),
     path('public_playlists/', views.get_all_shared_playlists, name='public_playlists'),
-    path('playlist/<int:playlist_id>/tracks/', views.playlist_tracks),
-    path('<int:playlist_id>/add/', views.add_track),
-    path('<int:playlist_id>/move-track/', views.move_track_in_playlist),
-    path('<int:playlist_id>/change-visibility/', views.change_visibility),
-    path('<int:playlist_id>/invite-user/', views.invite_user),
-    path('<int:playlist_id>/license/', views.patch_playlist_license),
-    path('<int:playlist_id>/tracks/vote/', views.vote_for_track),
+    path('playlist/<int:playlist_id>/tracks/', views.playlist_tracks, name='playlist_tracks'),
+    path('<int:playlist_id>/add/', views.add_track, name='add_track'),
+    path('<int:playlist_id>/move-track/', views.move_track_in_playlist, name='move_track_in_playlist'),
+    path('<int:playlist_id>/change-visibility/', views.change_visibility, name='change_visibility'),
+    path('<int:playlist_id>/invite-user/', views.invite_user, name='invite_user'),
+    path('<int:playlist_id>/license/', views.patch_playlist_license, name='patch_playlist_license'),
+    path('<int:playlist_id>/tracks/vote/', views.vote_for_track, name='vote_for_track'),
 
     # GET events
     path('saved_events/', views.get_user_saved_events, name='saved_events'),

--- a/apps/playlists/views.py
+++ b/apps/playlists/views.py
@@ -19,10 +19,13 @@ from apps.deezer.deezer_client import DeezerClient
 from .serializers import PlaylistLicenseSerializer, VoteSerializer
 from django.contrib.auth import get_user_model
 from django.db.models import Q
+from drf_spectacular.utils import extend_schema
+from .docs import *
+
 
 User = get_user_model()
 
-
+@create_new_playlist_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -51,6 +54,8 @@ def create_new_playlist(request):
         "playlist_id": playlist.id
     }, status=201)
 
+
+@update_playlist_schema
 @api_view(['PATCH'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -82,6 +87,7 @@ def update_playlist(request, playlist_id):
     return JsonResponse({"message": "Playlist updated successfully."}, status=200)
 
 
+@delete_playlist_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -98,6 +104,7 @@ def delete_playlist(request, playlist_id):
     return JsonResponse({"message": "Playlist deleted successfully."}, status=200)
 
 
+@get_user_saved_playlists_schema
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -126,6 +133,7 @@ def get_user_saved_playlists(request):
     return JsonResponse({'playlists': playlist_data})
 
 
+@get_all_shared_playlists_schema
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -189,6 +197,7 @@ def save_shared_playlist(request):
     }, status=201)
 
 
+@get_playlist_info_schema
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -221,6 +230,7 @@ def get_playlist_info(request, playlist_id):
         return JsonResponse({"error": "Playlist not found."}, status=404)
 
 
+@playlist_tracks_schema
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -239,6 +249,8 @@ def playlist_tracks(request, playlist_id):
 
     return JsonResponse({'playlist': playlist.name, 'tracks': data})
 
+
+@add_track_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -293,6 +305,7 @@ def add_track(request, playlist_id):
         return JsonResponse({'error': str(e)}, status=400)
 
 
+@move_track_in_playlist_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -350,6 +363,7 @@ def move_track_in_playlist(request, playlist_id):
         return JsonResponse({'error': str(e)}, status=400)
 
 
+@delete_track_from_playlist_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -403,6 +417,8 @@ def delete_track_from_playlist(request, playlist_id):
     except Exception as e:
         return JsonResponse({'error': str(e)}, status=400)
 
+
+@change_visibility_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -417,6 +433,8 @@ def change_visibility(request, playlist_id):
     except Exception as e:
         return JsonResponse({'error': str(e)}, status=400)    
 
+
+@invite_user_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -446,8 +464,10 @@ def invite_user(request, playlist_id):
         )
         return JsonResponse({'message': 'User invited to the playlist'}, status=201)
     except Exception as e:
-        return JsonResponse({'error': str(e)}, status=400) 
+        return JsonResponse({'error': str(e)}, status=400)
 
+
+@patch_playlist_license_schema
 @api_view(['PATCH'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -466,6 +486,8 @@ def patch_playlist_license(request, playlist_id):
         return JsonResponse(serializer.data, status=200)
     return JsonResponse(serializer.errors, status=400)
 
+
+@vote_for_track_schema
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])

--- a/apps/playlists/views.py
+++ b/apps/playlists/views.py
@@ -468,7 +468,7 @@ def invite_user(request, playlist_id):
 
 
 @patch_playlist_license_schema
-@api_view(['PATCH'])
+@api_view(['GET', 'PATCH'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
 def patch_playlist_license(request, playlist_id):
@@ -479,6 +479,10 @@ def patch_playlist_license(request, playlist_id):
 
     if playlist.creator != request.user:
         return JsonResponse({'detail': 'You do not have permission to edit this playlist license.'}, status=403)
+
+    if request.method == 'GET':
+        serializer = PlaylistLicenseSerializer(playlist)
+        return JsonResponse(serializer.data, status=200)
 
     serializer = PlaylistLicenseSerializer(playlist, data=request.data, partial=True)
     if serializer.is_valid():


### PR DESCRIPTION
Back-end

Added swagger API documentation and pytest to the following playlists APIs:

    path('playlists', views.create_new_playlist, name='playlists'),
    path('playlists/<int:playlist_id>', views.get_playlist_info, name='get_playlist'),
    path('update_playlist/<int:playlist_id>', views.update_playlist, name='update_playlist'),
    path('delete_playlist/<int:playlist_id>', views.delete_playlist, name='delete_playlist'),
    path('playlists/<int:playlist_id>/remove_tracks', views.delete_track_from_playlist, name='remove_items'),
    path('saved_playlists/', views.get_user_saved_playlists, name='saved_playlists'),
    path('public_playlists/', views.get_all_shared_playlists, name='public_playlists'),
    path('playlist/<int:playlist_id>/tracks/', views.playlist_tracks, name='playlist_tracks'),
    path('<int:playlist_id>/add/', views.add_track, name='add_track'),
    path('<int:playlist_id>/move-track/', views.move_track_in_playlist, name='move_track_in_playlist'),
    path('<int:playlist_id>/change-visibility/', views.change_visibility, name='change_visibility'),
    path('<int:playlist_id>/invite-user/', views.invite_user, name='invite_user'),
    path('<int:playlist_id>/license/', views.patch_playlist_license, name='patch_playlist_license'),
    path('<int:playlist_id>/tracks/vote/', views.vote_for_track, name='vote_for_track'),


